### PR TITLE
inst_target_part.ycp: Fix encoding to UTF-8

### DIFF
--- a/storage/src/inst_target_part.ycp
+++ b/storage/src/inst_target_part.ycp
@@ -23,7 +23,7 @@
  * Module:		inst_target_part.ycp
  *
  * Authors:		Andreas Schwab (schwab@suse.de)
- *			Klaus Kämpf (kkaempf@suse.de)
+ *			Klaus KÃ¤mpf (kkaempf@suse.de)
  *
  * Purpose:		This module ask the user which partition to use:
  *			-Determing possible partitions.


### PR DESCRIPTION
Without this, Ruby translation of this file won't work.
