### PR TITLE
Use UTF-8 enconding in code

### DIFF
--- a/storage/src/include/auto_part_create.ycp
+++ b/storage/src/include/auto_part_create.ycp
@@ -23,7 +23,7 @@
  * Module:		auto_part_create.ycp
  *
  * Authors:		Andreas Schwab (schwab@suse.de)
- *			Klaus Kämpf (kkaempf@suse.de)
+ *			Klaus KÃ¤mpf (kkaempf@suse.de)
  *
  * Purpose:		This module creates the neccessary partitions
  *			in the targetMap

--- a/storage/src/include/auto_part_functions.ycp
+++ b/storage/src/include/auto_part_functions.ycp
@@ -23,7 +23,7 @@
  * Module: 		auto_part_functions.ycp
  *
  * Authors: 		Andreas Schwab (schwab@suse.de)
- *			Klaus K‰mpf (kkaempf@suse.de)
+ *			Klaus K√§mpf (kkaempf@suse.de)
  *
  * Purpose: 		This module define functions of general use
  *			to the automatic partitioner
@@ -175,8 +175,8 @@ define boolean is_fat_partition( map partition ) ``{
     //
 define boolean is_ntfs_partition( map partition ) ``{
 	return ( partition["fsid"]:-1 == 0x07 || 	// HPFS/NTFS
-		 partition["fsid"]:-1 == 0x86 || 	// NTFS-Datentr‰ger
-		 partition["fsid"]:-1 == 0x87 );	// NTFS-Datentr‰ger
+		 partition["fsid"]:-1 == 0x86 || 	// NTFS-Datentr√§ger
+		 partition["fsid"]:-1 == 0x87 );	// NTFS-Datentr√§ger
     }
 
     

--- a/storage/src/include/auto_part_prepare.ycp
+++ b/storage/src/include/auto_part_prepare.ycp
@@ -23,7 +23,7 @@
  * Module: 		auto_part_prepare.ycp
  *
  * Authors: 		Andreas Schwab (schwab@suse.de)
- *			Klaus Kämpf (kkaempf@suse.de)
+ *			Klaus KÃ¤mpf (kkaempf@suse.de)
  *
  * Purpose: 		This module preparse the raw targetMap to
  *			cover the whole disk, including unpartitioned

--- a/storage/src/include/auto_part_ui.ycp
+++ b/storage/src/include/auto_part_ui.ycp
@@ -23,7 +23,7 @@
  * Module: 		auto_part_ui.ycp
  *
  * Authors: 		Andreas Schwab (schwab@suse.de)
- *			Klaus Kämpf (kkaempf@suse.de)
+ *			Klaus KÃ¤mpf (kkaempf@suse.de)
  *
  * Purpose: 		This module contains the user interface
  *			definitions for the automatic partitioner

--- a/storage/src/modules/Storage.ycp
+++ b/storage/src/modules/Storage.ycp
@@ -29,16 +29,16 @@
  * to * access and modify the partitioning settings.
  *
  * Todo: Translate
- * Diese Modul enthält alle Informationen die für die Partitionierung der
+ * Diese Modul enthÃ¤lt alle Informationen die fÃ¼r die Partitionierung der
  * Festplatten erforderlich sind. Diese Informationen bestehen aus der
  * Beschreibung, der vor der Partitionierung vorhandenen Platteneinstellungen,
- * und der Art und Weise wie diese verändert werden soll.
- * Alle nötigen Zugriffsfunktionen auf diese Datenstruktur sind ebenfalls in
+ * und der Art und Weise wie diese verÃ¤ndert werden soll.
+ * Alle nÃ¶tigen Zugriffsfunktionen auf diese Datenstruktur sind ebenfalls in
  * diesem Modul enthalten. Der Zugriff auf die Speicherung der
- * Partitionseinstellungen läuft also nur über dieses Modul.
- * Der Zugriff und die Rückgabe von Teilen der Partitionsdatenstruktur
+ * Partitionseinstellungen lÃ¤uft also nur Ã¼ber dieses Modul.
+ * Der Zugriff und die RÃ¼ckgabe von Teilen der Partitionsdatenstruktur
  * wurde versucht "intelligent" zu gestallten und ist im einzelen bei den
- * entspechenden Funktionen näher erklärt.
+ * entspechenden Funktionen nÃ¤her erklÃ¤rt.
  *
  * $Id$
  */


### PR DESCRIPTION
Ruby need to have unified enconding over whole file and to be consistent
we choose UTF-8 that is already used on some place. This commit makes also
storage module consistent.
