### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/modules/DevicesSelectionBox.rb
+++ b/src/modules/DevicesSelectionBox.rb
@@ -125,7 +125,7 @@ module Yast
       @devices = Builtins.flatten([unselected_devices, selected_devices])
 
       @selected_size_function = new_selected_size_function != nil ?
-        new_selected_size_function :
+        deep_copy(new_selected_size_function) :
         fun_ref(method(:Sum), "integer (list <map>)")
 
       device_names = Builtins.maplist(@devices) do |device|

--- a/src/modules/StorageFields.rb
+++ b/src/modules/StorageFields.rb
@@ -487,7 +487,7 @@ module Yast
     def MakeSubInfo(disk, part, field, style)
       disk = deep_copy(disk)
       part = deep_copy(part)
-      data = part == nil ? disk : part
+      data = part == nil ? deep_copy(disk) : deep_copy(part)
       type = part == nil ?
         Ops.get_symbol(disk, "type", :primary) :
         Ops.get_symbol(part, "type", :CT_DISK)


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
