### PR TITLE
Fix grub2 architecture name for PowerPC

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 03 15:20:42 CEST 2014 - dvaleev@suse.com
+
+- Fix GRUB2 architecture name for PowerPC
+- version 3.1.34
+
+-------------------------------------------------------------------
 Mon Jun 30 14:37:06 CEST 2014 - aschnell@suse.de
 
 - enable btrfs quota if snapshots are enabled (prototype for

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.33
+Version:        3.1.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Storage.rb
+++ b/src/modules/Storage.rb
@@ -4974,7 +4974,7 @@ module Yast
       end
 
       if Arch.ppc
-        def_subvol.push("boot/grub2/power-ieee1275")
+        def_subvol.push("boot/grub2/powerpc-ieee1275")
       end
 
       if Arch.s390

--- a/testsuite/tests/empty-big-ppc64le1.out
+++ b/testsuite/tests/empty-big-ppc64le1.out
@@ -2,7 +2,7 @@ Dump	Proposal:
 Dump	Create GPT PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (517.72 MiB)
 Dump	Create root volume /dev/sda3 (2.50 TiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda3
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda3
 Dump	Create subvolume home on device /dev/sda3
 Dump	Create subvolume opt on device /dev/sda3
 Dump	Create subvolume srv on device /dev/sda3

--- a/testsuite/tests/empty-big-ppc64le2.out
+++ b/testsuite/tests/empty-big-ppc64le2.out
@@ -5,7 +5,7 @@ Dump	Create volume group system (2.50 TiB) from /dev/sda2 [destructive]
 Dump	Create logical volume /dev/system/home (50.00 GiB) for /home with xfs
 Dump	Create root volume /dev/system/root (20.00 GiB) with btrfs
 Dump	Create swap logical volume /dev/system/swap (768.00 MiB)
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/system/root
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/system/root
 Dump	Create subvolume opt on device /dev/system/root
 Dump	Create subvolume srv on device /dev/system/root
 Dump	Create subvolume tmp on device /dev/system/root

--- a/testsuite/tests/empty-ppc64le1.out
+++ b/testsuite/tests/empty-ppc64le1.out
@@ -2,7 +2,7 @@ Dump	Proposal:
 Dump	Create PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (517.72 MiB)
 Dump	Create root volume /dev/sda3 (297.58 GiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda3
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda3
 Dump	Create subvolume home on device /dev/sda3
 Dump	Create subvolume opt on device /dev/sda3
 Dump	Create subvolume srv on device /dev/sda3

--- a/testsuite/tests/empty-ppc64le2.out
+++ b/testsuite/tests/empty-ppc64le2.out
@@ -3,7 +3,7 @@ Dump	Create PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (2.01 GiB)
 Dump	Create root volume /dev/sda3 (40.00 GiB) with btrfs
 Dump	Create volume /dev/sda4 (256.07 GiB) for /home with xfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda3
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda3
 Dump	Create subvolume opt on device /dev/sda3
 Dump	Create subvolume srv on device /dev/sda3
 Dump	Create subvolume tmp on device /dev/sda3

--- a/testsuite/tests/empty-ppc64le3.out
+++ b/testsuite/tests/empty-ppc64le3.out
@@ -5,7 +5,7 @@ Dump	Create volume group system (298.07 GiB) from /dev/sda2 [destructive]
 Dump	Create logical volume /dev/system/home (50.00 GiB) for /home with xfs
 Dump	Create root volume /dev/system/root (20.00 GiB) with btrfs
 Dump	Create swap logical volume /dev/system/swap (768.00 MiB)
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/system/root
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/system/root
 Dump	Create subvolume opt on device /dev/system/root
 Dump	Create subvolume srv on device /dev/system/root
 Dump	Create subvolume tmp on device /dev/system/root

--- a/testsuite/tests/flex-info-empty-big-ppc64le1.out
+++ b/testsuite/tests/flex-info-empty-big-ppc64le1.out
@@ -3,7 +3,7 @@ Dump	Create GPT PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (1.00 GiB)
 Dump	Create volume /dev/sda3 (2.49 TiB) for /data with btrfs
 Dump	Create root volume /dev/sda4 (8.01 GiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda4
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda4
 Dump	Create subvolume home on device /dev/sda4
 Dump	Create subvolume opt on device /dev/sda4
 Dump	Create subvolume srv on device /dev/sda4

--- a/testsuite/tests/flex-info-empty-ppc64le1.out
+++ b/testsuite/tests/flex-info-empty-ppc64le1.out
@@ -3,7 +3,7 @@ Dump	Create PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (1.00 GiB)
 Dump	Create volume /dev/sda3 (289.07 GiB) for /data with btrfs
 Dump	Create root volume /dev/sda4 (8.01 GiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda4
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda4
 Dump	Create subvolume home on device /dev/sda4
 Dump	Create subvolume opt on device /dev/sda4
 Dump	Create subvolume srv on device /dev/sda4

--- a/testsuite/tests/flex-info-empty-ppc64le2.out
+++ b/testsuite/tests/flex-info-empty-ppc64le2.out
@@ -3,7 +3,7 @@ Dump	Create PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (1.00 GiB)
 Dump	Create volume /dev/sda3 (289.07 GiB) for /data with btrfs
 Dump	Create root volume /dev/sda4 (8.01 GiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda4
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda4
 Dump	Create subvolume home on device /dev/sda4
 Dump	Create subvolume opt on device /dev/sda4
 Dump	Create subvolume srv on device /dev/sda4

--- a/testsuite/tests/flex-xml-empty-ppc64le1.out
+++ b/testsuite/tests/flex-xml-empty-ppc64le1.out
@@ -3,7 +3,7 @@ Dump	Create PReP volume /dev/sda1 (7.84 MiB)
 Dump	Create swap volume /dev/sda2 (1.00 GiB)
 Dump	Create volume /dev/sda3 (289.07 GiB) for /data with btrfs
 Dump	Create root volume /dev/sda4 (8.01 GiB) with btrfs
-Dump	Create subvolume boot/grub2/power-ieee1275 on device /dev/sda4
+Dump	Create subvolume boot/grub2/powerpc-ieee1275 on device /dev/sda4
 Dump	Create subvolume home on device /dev/sda4
 Dump	Create subvolume opt on device /dev/sda4
 Dump	Create subvolume srv on device /dev/sda4


### PR DESCRIPTION
Fix grub2 architecture name typo power-ieee1275 -> powerpc-ieee1275

Signed-off-by: Dinar Valeev dvaleev@suse.com
