### PR TITLE
Fixed bsc#922308: No snapper config for LVM storage proposal

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  9 11:41:38 CEST 2015 - shundhammer@suse.de
+
+- No snapper config for LVM storage proposal (bsc#922308)
+- version 3.1.56
+
+-------------------------------------------------------------------
 Wed May 06 16:34:04 CEST 2015 - aschnell@suse.de
 
 - require rubygems of default ruby version (bsc#929899)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.55
+Version:        3.1.56
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -4440,7 +4440,10 @@ module Yast
 
       end
 
+
       def modify(partitions)
+
+        Builtins.y2milestone( "Post-processing partitions..." )
 
         partitions.each do |volume|
 
@@ -4475,6 +4478,9 @@ module Yast
               size_limit_k = 1024 * opts["root_base"]
               if volume["size_k"] >= size_limit_k
                 volume["userdata"] = { "/" => "snapshots" }
+                Builtins.y2milestone( "Adding userdata '/' => 'snapshots'" )
+              else
+                Builtins.y2milestone( "Below size limit - NOT adding userdata '/' => 'snapshots'" )
               end
             end
           end
@@ -6095,7 +6101,14 @@ module Yast
         )
         Builtins.y2milestone("get_proposal_vm sol:%1", disk)
       end
-      Builtins.y2milestone("get_proposal_vm ret:%1", ret)
+
+      post_processor = PostProcessor.new()
+      ret["target"] = post_processor.process_target(ret["target"])
+
+      Builtins.y2milestone(
+        "get_proposal_vm ret[ok]: %1",
+        Ops.get_boolean(ret, "ok", false)
+      )
       deep_copy(ret)
     end
 


### PR DESCRIPTION
- Added logging to the PostProcessor so it's much easier to check in the logs if making snapshots was even considered there

- Added the missing PostProcessor call to that code path in question