### PR TITLE
Allow /boot on RAID1 for PowerPC

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 17 13:31:34 CEST 2015 - dvaleev@suse.com
+
+- Allow /boot on RAID1 (bsc#938170)
+- 3.1.63
+
+-------------------------------------------------------------------
 Thu Jul 16 14:33:10 CEST 2015 - aschnell@suse.de
 
 - do not try to load snapper extension since it does not exist

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.62
+Version:        3.1.63
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_lib.rb
+++ b/src/include/partitioning/custom_part_lib.rb
@@ -73,9 +73,9 @@ module Yast
     # @param [String] mount mount point
     # @return [Boolean]
     #
-    def check_raid_mount_points(mount)
+    def check_raid_mount_points(mount, raid_level)
       not_allowed_raid_mount_points = []
-      if Arch.ppc || Arch.s390
+      if (Arch.ppc && raid_level != "raid1") || Arch.s390
         not_allowed_raid_mount_points = Builtins.add(
           not_allowed_raid_mount_points,
           Partitions.BootMount
@@ -360,7 +360,7 @@ module Yast
           Ops.set(ret, "field", :mount_point)
         end
         if Ops.get_symbol(new, "type", :primary) == :sw_raid
-          if !check_raid_mount_points(Ops.get_string(new, "mount", ""))
+          if !check_raid_mount_points(Ops.get_string(new, "mount", ""), Ops.get_string(new, "raid_type", ""))
             Ops.set(ret, "ok", false)
             Ops.set(ret, "field", :mount_point)
           end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,7 +5,8 @@
 TESTS = \
 	format_target_map_test.rb					\
 	storage_snapper_configure_snapper_test.rb			\
-	storage_get_disk_partition.rb
+	storage_get_disk_partition.rb					\
+	storage_boot_on_raid1.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/storage_boot_on_raid1.rb
+++ b/test/storage_boot_on_raid1.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env rspec
+
+$LOAD_PATH.unshift File.expand_path('../../src', __FILE__)
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+require "yast"
+
+require "include/partitioning/custom_part_lib"
+
+class CustomPartLib < Yast::Client
+  include Singleton
+  def initialize
+    Yast.include self, "partitioning/custom_part_lib.rb"
+  end
+end
+
+Yast.import "Arch"
+Yast.import "Partitions"
+
+describe "CustomPartLib#CheckOkMount" do
+
+
+  it "/boot is only possible with RAID1 on PowerPC" do
+
+    allow(Yast::Arch).to receive(:architecture).and_return("ppc")
+    allow(Yast::Partitions).to receive(:EfiBoot).and_return(false)
+
+    expect(CustomPartLib.instance.check_raid_mount_points("/boot", "raid1")).to eq true
+  end
+
+  it "We cannot put /boot/zipl on any RAID" do
+
+    allow(Yast::Arch).to receive(:architecture).and_return("s390_64")
+    allow(Yast::Partitions).to receive(:EfiBoot).and_return(false)
+
+    expect(CustomPartLib.instance.check_raid_mount_points("/boot/zipl", "raid1")).to eq false
+  end
+
+  it "x86 can boot with /boot on RAID1 " do
+
+    allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
+    allow(Yast::Partitions).to receive(:EfiBoot).and_return(false)
+
+    expect(CustomPartLib.instance.check_raid_mount_points("/boot", "raid1")).to eq true
+  end
+
+end


### PR DESCRIPTION
PowerPC bootloaders are able to read raid1 partition

Fixes bsc#938170

Signed-off-by: Dinar Valeev <dvaleev@suse.com>