### PR TITLE
Fix special /boot handling on SLE12

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug  7 07:41:05 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix special /boot handling on custom partitioning (bsc#940374)
+
+-------------------------------------------------------------------
 Thu Sep 18 16:34:43 CEST 2014 - aschnell@suse.de
 
 - fixed btrfs subvolume handling for non-root devices (bnc#895075)

--- a/src/include/partitioning/ep-main.rb
+++ b/src/include/partitioning/ep-main.rb
@@ -733,6 +733,12 @@ module Yast
           Storage.SetPartMode("CUSTOM") if Storage.GetPartMode == "NORMAL"
         when :next
           if !Storage.EqualBackupStates("expert-partitioner", "", true)
+            # Handle boot partition (bsc#940374) during installation
+            if Stage.initial && !Mode.repair
+              new_tgmap = Storage.SpecialBootHandling(Storage.GetTargetMap())
+              Storage.SetTargetMap(new_tgmap)
+            end
+
             Storage.SetPartMode("CUSTOM")
             Storage.UpdateChangeTime
           end


### PR DESCRIPTION
It fixes https://bugzilla.suse.com/show_bug.cgi?id=940374. The real problem is that, although the installer warns about converting automatically /boot partition to PReP, it does not nothing about that (on expert partitioner).