### PR TITLE
Fix special /boot handling on SLE12 SP1

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug  7 07:41:05 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix special /boot handling on custom partitioning (bsc#940374)
+- 3.1.65
+
+-------------------------------------------------------------------
 Thu Jul 23 11:44:42 CEST 2015 - shundhammer@suse.de
 
 - Added NoCoW subvolume for /var/lib/libvirt/images (Fate#319299)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.64
+Version:        3.1.65
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/ep-main.rb
+++ b/src/include/partitioning/ep-main.rb
@@ -723,6 +723,12 @@ module Yast
           Storage.SetPartMode("CUSTOM") if Storage.GetPartMode == "NORMAL"
         when :next
           if !Storage.EqualBackupStates("expert-partitioner", "", true)
+            # Handle boot partition (bsc#940374) during installation
+            if Stage.initial && !Mode.repair
+              new_tgmap = Storage.SpecialBootHandling(Storage.GetTargetMap())
+              Storage.SetTargetMap(new_tgmap)
+            end
+
             Storage.SetPartMode("CUSTOM")
             Storage.UpdateChangeTime
           end


### PR DESCRIPTION
The same fix that PR https://github.com/yast/yast-storage/pull/146 but for SLE12 SP1. Manually tested on ppc64le and x86_64.