### PR TITLE
don't create btrfs subvolumes outside the root fs (bsc#940797)

### DIFF
--- a/src/modules/Storage.rb
+++ b/src/modules/Storage.rb
@@ -4978,6 +4978,28 @@ module Yast
     end
 
 
+    def SubvolShadowed?(subvol)
+      shadowed = false
+      tmp = "/" + subvol
+
+      GetTargetMap().each do |dev, disk|
+        parts = disk.fetch("partitions", [])
+        parts.each do |part|
+          if part.has_key?("mount")
+            mp = part["mount"]
+            if (tmp == mp) || (tmp.start_with?(mp) && tmp[mp.size] == "/")
+              shadowed = true
+            end
+          end
+        end
+      end
+
+      Builtins.y2milestone("SubvolShadowed?( %1 ): %2", subvol, shadowed)
+
+      shadowed
+    end
+
+
     def AddSubvolRoot(part)
       part = deep_copy(part)
 
@@ -5041,7 +5063,7 @@ module Yast
       Builtins.y2milestone("AddSubvolRoot subvol names: %1 subvol_list: %2", names, subvol_list)
       subvol_names.each do |subvol|
         subvol_full_name = subvol_prepend + subvol
-        if !names.include?( subvol_full_name )
+        if !names.include?( subvol_full_name ) && !SubvolShadowed?( subvol )
           subvol_entry = { "create" => true, "name" => subvol_full_name }
           if nocow_subvols.include?( subvol )
             subvol_entry["nocow"] = true


### PR DESCRIPTION
Although yast already warns about such a setup it would be nice not to propose
such a setting in the first place.
The code is inspired by check_created_partition_table().