### PR TITLE
Btrfs on lvm

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 19 15:18:26 CEST 2015 - locilka@suse.com
+
+- New Storage::SetUserdata() (for bsc#935858, patch by aschnell)
+- 3.1.45.1
+
+-------------------------------------------------------------------
 Fri Aug  7 07:41:05 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix special /boot handling on custom partitioning (bsc#940374)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.45
+Version:        3.1.45.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -35,6 +35,7 @@ BuildRequires:	libxslt
 BuildRequires:	perl-XML-Writer
 BuildRequires:	rubygem(rspec)
 BuildRequires:	rubygem(ruby-dbus)
+BuildRequires:	rubygem(yast-rake)
 BuildRequires:	sgml-skel
 BuildRequires:	update-desktop-files
 BuildRequires:	yast2 >= 3.1.22

--- a/src/modules/Storage.rb
+++ b/src/modules/Storage.rb
@@ -2722,8 +2722,27 @@ module Yast
     end
 
 
-    def ChangeDescText(dev, txt)
-      ret = @sint.changeDescText(dev, txt)
+    def ChangeDescText(device, text)
+      @sint.changeDescText(device, text)
+    end
+
+
+    # Sets a key-value pairs of data for a given device
+    #
+    # @param [String] device
+    # @param [Map] user data
+    # @return [Integer] error number, 0 if successful
+    def SetUserData(device, user_data)
+      log.info "Setting user data #{user_data} for #{device}"
+      set_user_data = ::Storage::MapStringString.new()
+
+      user_data.each do |key, value|
+        set_user_data[key] = value
+      end
+
+      ret = @sint.setUserdata(device, set_user_data)
+      UpdateTargetMap()
+      ret
     end
 
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,8 +3,7 @@
 #
 
 TESTS = \
-  storage_utils_configure_snapper_test.rb \
-  storage_test.rb
+  storage_utils_configure_snapper_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,9 @@
 # Makefile.am for storage/test
 #
 
-TESTS = storage_utils_configure_snapper_test.rb
+TESTS = \
+  storage_utils_configure_snapper_test.rb \
+  storage_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env rspec
+
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+require "yast"
+
+Yast.import "Storage"
+Yast.import "StorageInit"
+
+describe "Yast::Storage" do
+  before do
+    Yast::Storage.InitLibstorage(false)
+  end
+
+  describe "#SetUserData" do
+    it "sets given user data for a given device" do
+      # non-zero error for device that does not exist
+      expect(Yast::Storage.SetUserData("/dev/ice/does/not/exist", { "/" => "snapshots" })).not_to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Doesn't pass the test case in build with `Can't import StorageCallbacks`, but it works on the running system.