### PR TITLE
Fix LVM on expert partitioner

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 11 09:28:45 UTC 2015 - igonzalezsosa@suse.com
+
+- Expert partitioner does not forget logical volumes (bsc#944492)
+- 3.1.67
+
+-------------------------------------------------------------------
 Tue Aug 25 16:21:55 CEST 2015 - shundhammer@suse.de
 
 - Install storage related packages only on demand (bsc#937040)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.66
+Version:        3.1.67
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_check_generated.rb
+++ b/src/include/partitioning/custom_part_check_generated.rb
@@ -70,6 +70,7 @@ module Yast
       partition_mounted_but_not_formated = false
       swap_found = false
       boot_found = false
+      boot_mount_point = ""
       root_found = false
       gpt_boot_ia64 = false
       boot_end = 0
@@ -158,6 +159,7 @@ module Yast
               gpt_boot_ia64 = true
             end
             boot_found = true
+            boot_mount_point = mountpoint
             if Ops.get_symbol(diskinfo, "type", :CT_UNKNOWN) == :CT_DISK
               boot_end = Region.End(Ops.get_list(part, "region", []))
             else
@@ -174,6 +176,7 @@ module Yast
             if Partitions.PrepBoot &&
                 (fsid == Partitions.FsidBoot(dlabel) || fsid == 6)
               boot_found = true
+              boot_mount_point = mountpoint
               boot_end = Region.End(Ops.get_list(part, "region", []))
               boot_fs = Ops.get_symbol(part, "used_fs", :unknown)
               boot_size_k = Ops.get_integer(part, "size_k", 0)
@@ -181,11 +184,13 @@ module Yast
             elsif Arch.board_mac &&
                 Ops.get_symbol(part, "used_fs", :unknown) == :hfs
               boot_found = true
+              boot_mount_point = mountpoint
               boot_end = Region.End(Ops.get_list(part, "region", []))
               boot_fs = Ops.get_symbol(part, "used_fs", :unknown)
               boot_size_k = Ops.get_integer(part, "size_k", 0)
             elsif !Partitions.EfiBoot() && fsid == Partitions.fsid_bios_grub
               boot_found = true
+              boot_mount_point = mountpoint
               boot_end = Region.End(Ops.get_list(part, "region", []))
               boot_fs = :none
               boot_size_k = Ops.get_integer(part, "size_k", 0)
@@ -289,6 +294,20 @@ module Yast
             "system, such as ext3 or ext4, for this mount point.\n" +
             "\n" +
             "Really use this setup?\n"
+        )
+
+        ok = false if !Popup.YesNo(message)
+      end
+
+      # A PReP/CHRP partition is not supposed to be mounted. So if we find any
+      # other /boot partition, we should warn the user.
+      if boot_found && Partitions.PrepBoot && !boot_mount_point.empty? && !Arch.board_iseries && installation || show_all_popups
+        message = _(
+          "Warning:\n" \
+          "Your system needs a boot partition with type 0x41 PReP/CHRP.\n" \
+          "Please, consider creating one.\n" \
+          "\n" \
+          "Really use this setup?\n"
         )
 
         ok = false if !Popup.YesNo(message)

--- a/src/include/partitioning/custom_part_check_generated.rb
+++ b/src/include/partitioning/custom_part_check_generated.rb
@@ -360,9 +360,8 @@ module Yast
             _(
               "Warning: There is no partition mounted as /boot.\n" +
                 "To boot from your hard disk, a small /boot partition\n" +
-                "(approx. %1) is required.  Consider creating one.\n" +
-                "Partitions assigned to /boot will automatically be changed to\n" +
-                "type 0x41 PReP/CHRP.\n" +
+                "(approx. %1) is required.  Consider creating one\n" +
+                "with type 0x41 PReP/CHRP.\n" +
                 "\n" +
                 "Really use the setup without /boot partition?\n"
             ),

--- a/src/include/partitioning/ep-main.rb
+++ b/src/include/partitioning/ep-main.rb
@@ -723,12 +723,6 @@ module Yast
           Storage.SetPartMode("CUSTOM") if Storage.GetPartMode == "NORMAL"
         when :next
           if !Storage.EqualBackupStates("expert-partitioner", "", true)
-            # Handle boot partition (bsc#940374) during installation
-            if Stage.initial && !Mode.repair
-              new_tgmap = Storage.SpecialBootHandling(Storage.GetTargetMap())
-              Storage.SetTargetMap(new_tgmap)
-            end
-
             Storage.SetPartMode("CUSTOM")
             Storage.UpdateChangeTime
           end

--- a/test/fixtures/dmraid-ext4-boot-root.ycp
+++ b/test/fixtures/dmraid-ext4-boot-root.ycp
@@ -1,0 +1,102 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DMRAID,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/dmraid-ext4-boot.ycp
+++ b/test/fixtures/dmraid-ext4-boot.ycp
@@ -1,0 +1,143 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DMRAID,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-boot-fat.ycp
+++ b/test/fixtures/gpt-boot-fat.ycp
@@ -1,0 +1,128 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fsid" : 12,
+        "fstopt" : "umask=0002,utf8=true",
+        "fstype" : "Win95 FAT32 LBA",
+        "inactive" : true,
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `vfat,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-boot-raid0.ycp
+++ b/test/fixtures/gpt-boot-raid0.ycp
@@ -1,0 +1,288 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/md" : $[
+    "device" : "/dev/md",
+    "name" : "md",
+    "partitions" : [
+      $[
+        "chunk_size" : 32,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/boot",
+        "devices" : [
+          "/dev/vda1",
+          "/dev/vdb1"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "boot",
+        "nr" : 0,
+        "raid_type" : "raid0",
+        "sb_ver" : "01.00.00",
+        "size_k" : 1044224,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "chunk_size" : 32,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/root",
+        "devices" : [
+          "/dev/vda2",
+          "/dev/vdb2"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "4.0"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m4.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "root",
+        "nr" : 0,
+        "raid_type" : "raid0",
+        "sb_ver" : "01.00.00",
+        "size_k" : 26218080,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ]
+    ],
+    "type" : `CT_MD,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/boot",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/boot",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          65,
+          1632
+        ],
+        "size_k" : 13109040,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1697,
+          130
+        ],
+        "size_k" : 1044225,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vdb" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vdb",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vdb",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb1",
+        "nr" : 1,
+        "region" : [
+          0,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/boot",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/boot",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb2",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb2",
+        "nr" : 2,
+        "region" : [
+          65,
+          1632
+        ],
+        "size_k" : 13109040,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vdb3",
+        "nr" : 3,
+        "region" : [
+          1697,
+          130
+        ],
+        "size_k" : 1044225,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "2. Disk, 14.00 GiB, /dev/vdb, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "ndrI.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-boot-raid1.ycp
+++ b/test/fixtures/gpt-boot-raid1.ycp
@@ -1,0 +1,288 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/md" : $[
+    "device" : "/dev/md",
+    "name" : "md",
+    "partitions" : [
+      $[
+        "chunk_size" : 4,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/boot",
+        "devices" : [
+          "/dev/vda1",
+          "/dev/vdb1"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "boot",
+        "nr" : 0,
+        "raid_type" : "raid1",
+        "sb_ver" : "01.00.00",
+        "size_k" : 522112,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "chunk_size" : 4,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/root",
+        "devices" : [
+          "/dev/vda2",
+          "/dev/vdb2"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "root",
+        "nr" : 0,
+        "raid_type" : "raid1",
+        "sb_ver" : "01.00.00",
+        "size_k" : 13109040,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ]
+    ],
+    "type" : `CT_MD,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/boot",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/boot",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          65,
+          1632
+        ],
+        "size_k" : 13109040,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1697,
+          130
+        ],
+        "size_k" : 1044225,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vdb" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vdb",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vdb",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb1",
+        "nr" : 1,
+        "region" : [
+          0,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/boot",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/boot",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb2",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb2",
+        "nr" : 2,
+        "region" : [
+          65,
+          1632
+        ],
+        "size_k" : 13109040,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vdb3",
+        "nr" : 3,
+        "region" : [
+          1697,
+          130
+        ],
+        "size_k" : 1044225,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "2. Disk, 14.00 GiB, /dev/vdb, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "ndrI.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-btrfs-boot.ycp
+++ b/test/fixtures/gpt-btrfs-boot.ycp
@@ -1,0 +1,177 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fsid" : 131,
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "12346",
+            "type" : `UB_BTRFS
+          ]
+        ],
+        "used_by_device" : "12346",
+        "used_by_type" : `UB_BTRFS,
+        "used_fs" : `btrfs,
+        "uuid" : "12346"
+      ],
+      $[
+        "detected_fs" : `swap,
+        "device" : "/dev/vda2",
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1,
+          262
+        ],
+        "size_k" : 2110464,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap,
+        "uuid" : "8d3205b9-3dbf-4c58-9b67-861a8e7587d5"
+      ],
+      $[
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 131,
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          34,
+          1565
+        ],
+        "size_k" : 12566528,
+        "subvol" : [
+          $[
+            "create" : true,
+            "name" : "@/home"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/srv"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/tmp"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/usr/local"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/crash"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/libvirt/images",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mailman"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mariadb",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/named"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/pgsql",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/log"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/spool"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/tmp"
+          ]
+        ],
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "12345",
+            "type" : `UB_BTRFS
+          ]
+        ],
+        "used_by_device" : "12345",
+        "used_by_type" : `UB_BTRFS,
+        "used_fs" : `btrfs,
+        "uuid" : "12345"
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-btrfs.ycp
+++ b/test/fixtures/gpt-btrfs.ycp
@@ -1,0 +1,172 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 263,
+        "fstype" : "BIOS Grub",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1
+        ],
+        "size_k" : 1024,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE
+      ],
+      $[
+        "detected_fs" : `swap,
+        "device" : "/dev/vda2",
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1,
+          262
+        ],
+        "size_k" : 2110464,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap,
+        "uuid" : "8d3205b9-3dbf-4c58-9b67-861a8e7587d5"
+      ],
+      $[
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 131,
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          262,
+          1565
+        ],
+        "size_k" : 12566528,
+        "subvol" : [
+          $[
+            "create" : true,
+            "name" : "@/boot/grub2/i386-pc"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/boot/grub2/x86_64-efi"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/home"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/srv"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/tmp"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/usr/local"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/crash"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/libvirt/images",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mailman"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mariadb",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/named"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/pgsql",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/log"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/spool"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/tmp"
+          ]
+        ],
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "12345",
+            "type" : `UB_BTRFS
+          ]
+        ],
+        "used_by_device" : "12345",
+        "used_by_type" : `UB_BTRFS,
+        "used_fs" : `btrfs,
+        "uuid" : "12345"
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-ppc-btrfs.ycp
+++ b/test/fixtures/gpt-ppc-btrfs.ycp
@@ -1,0 +1,199 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+      $[
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda3",
+        "devices" : [
+          "/dev/sda3"
+        ],
+        "format" : true,
+        "fstype" : "BTRFS",
+        "inactive" : true,
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "sda3",
+        "size_k" : 18852277,
+        "subvol" : [
+          $[
+            "create" : true,
+            "name" : "@/boot/grub2/powerpc-ieee1275"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/home"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/srv"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/tmp"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/usr/local"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/crash"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mailman"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/named"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/pgsql"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/log"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/spool"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/tmp"
+          ]
+        ],
+        "type" : `btrfs,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part3"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part3",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `btrfs,
+        "userdata" : $[
+          "/" : "snapshots"
+        ],
+        "uuid" : "12345"
+      ]
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/sda" : $[
+    "bios_id" : "vdevice/v-scsi@2000/@0",
+    "bus" : "SCSI",
+    "cyl_count" : 2610,
+    "cyl_size" : 8225280,
+    "device" : "/dev/sda",
+    "driver" : "ibmvscsi",
+    "driver_module" : "ibmvscsi",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 128,
+    "model" : "QEMU HARDDISK",
+    "name" : "sda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda1",
+        "fsid" : 264,
+        "fstype" : "GPT PReP",
+        "name" : "sda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1
+        ],
+        "size_k" : 8032,
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part1"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part1",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "sda2",
+        "nr" : 2,
+        "region" : [
+          1,
+          262
+        ],
+        "size_k" : 2104515,
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part2"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part2",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/sda3",
+        "fsid" : 131,
+        "fstype" : "Linux native",
+        "name" : "sda3",
+        "nr" : 3,
+        "region" : [
+          263,
+          2347
+        ],
+        "size_k" : 18852277,
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part3"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part3",
+        "used_by" : [
+          $[
+            "device" : "12345",
+            "type" : `UB_BTRFS
+          ]
+        ],
+        "used_by_device" : "12345",
+        "used_by_type" : `UB_BTRFS,
+        "used_fs" : `btrfs
+      ]
+    ],
+    "proposal_name" : "1. SCSI Disk, 20.00 GiB, /dev/sda, QEMU-QEMU HARDDISK",
+    "sector_size" : 512,
+    "size_k" : 20971520,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "udev_id" : [
+      "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0"
+    ],
+    "udev_path" : "scsi-0:0:0:0",
+    "unique" : "WdzZ.f4FMrnpeQ69",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE,
+    "vendor" : "QEMU"
+  ]
+]

--- a/test/fixtures/gpt-root-raid0.ycp
+++ b/test/fixtures/gpt-root-raid0.ycp
@@ -1,0 +1,198 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/md" : $[
+    "device" : "/dev/md",
+    "name" : "md",
+    "partitions" : [
+      $[
+        "chunk_size" : 32,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/root",
+        "devices" : [
+          "/dev/vda1",
+          "/dev/vdb1"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "3.7"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m3.7",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "root",
+        "nr" : 0,
+        "raid_type" : "raid0",
+        "sb_ver" : "01.00.00",
+        "size_k" : 28306530,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ]
+    ],
+    "type" : `CT_MD,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vdb" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vdb",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vdb",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vdb2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "2. Disk, 14.00 GiB, /dev/vdb, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "ndrI.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/gpt-root-raid1.ycp
+++ b/test/fixtures/gpt-root-raid1.ycp
@@ -1,0 +1,198 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/md" : $[
+    "device" : "/dev/md",
+    "name" : "md",
+    "partitions" : [
+      $[
+        "chunk_size" : 4,
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/md/root",
+        "devices" : [
+          "/dev/vda1",
+          "/dev/vdb1"
+        ],
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "MD RAID",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "root",
+        "nr" : 0,
+        "raid_type" : "raid1",
+        "sb_ver" : "01.00.00",
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `sw_raid,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ]
+    ],
+    "type" : `CT_MD,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vdb" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vdb",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "gpt",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vdb",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb1",
+        "fsid" : 253,
+        "fstype" : "Linux RAID",
+        "name" : "vdb1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "/dev/md/root",
+            "type" : `UB_MD
+          ]
+        ],
+        "used_by_device" : "/dev/md/root",
+        "used_by_type" : `UB_MD
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vdb2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vdb2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "2. Disk, 14.00 GiB, /dev/vdb, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "ndrI.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-boot-ext4.ycp
+++ b/test/fixtures/msdos-boot-ext4.ycp
@@ -1,0 +1,143 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-boot-fat.ycp
+++ b/test/fixtures/msdos-boot-fat.ycp
@@ -1,0 +1,127 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fsid" : 12,
+        "fstopt" : "umask=0002,utf8=true",
+        "fstype" : "Win95 FAT32 LBA",
+        "inactive" : true,
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `vfat,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-btrfs-shadowed.ycp
+++ b/test/fixtures/msdos-btrfs-shadowed.ycp
@@ -1,0 +1,225 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fsid" : 131,
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1632
+        ],
+        "size_k" : 13109040,
+        "subvol" : [
+          $[
+            "create" : true,
+            "name" : "@/boot/grub2/i386-pc"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/boot/grub2/x86_64-efi"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/home"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/srv"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/tmp"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/usr/local"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/crash"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/libvirt/images",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mailman"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/mariadb",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/named"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/lib/pgsql",
+            "nocow" : true
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/log"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/opt"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/spool"
+          ],
+          $[
+            "create" : true,
+            "name" : "@/var/tmp"
+          ]
+        ],
+        "type" : `primary,
+        "used_by" : [
+          $[
+            "device" : "12345",
+            "type" : `UB_BTRFS
+          ]
+        ],
+        "used_by_device" : "12345",
+        "used_by_type" : `UB_BTRFS,
+        "used_fs" : `btrfs,
+        "userdata" : $[
+          "/" : "snapshots"
+        ],
+        "uuid" : "12345"
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1665,
+          162
+        ],
+        "size_k" : 1301265,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vdb" : $[
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vdb",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vdb",
+    "partitions" : [
+    ],
+    "proposal_name" : "2. Disk, 14.00 GiB, /dev/vdb, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "ndrI.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-ext4-boot-root.ycp
+++ b/test/fixtures/msdos-ext4-boot-root.ycp
@@ -1,0 +1,102 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          1762,
+          65
+        ],
+        "size_k" : 522112,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DMDISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-ext4-boot.ycp
+++ b/test/fixtures/msdos-ext4-boot.ycp
@@ -1,0 +1,143 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 0,
+    "max_primary" : 15,
+    "name" : "vda",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `btrfs,
+        "device" : "/dev/vda1",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/boot",
+        "mountby" : `uuid,
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          33
+        ],
+        "size_k" : 265072,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/fixtures/msdos-hfs.ycp
+++ b/test/fixtures/msdos-hfs.ycp
@@ -1,0 +1,126 @@
+$[
+  "/dev/sda" : $[
+    "bios_id" : "vdevice/v-scsi@2000/@0",
+    "bus" : "SCSI",
+    "cyl_count" : 2610,
+    "cyl_size" : 8225280,
+    "device" : "/dev/sda",
+    "driver" : "ibmvscsi",
+    "driver_module" : "ibmvscsi",
+    "label" : "msdos",
+    "max_logical" : 255,
+    "max_primary" : 4,
+    "model" : "QEMU HARDDISK",
+    "name" : "sda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda1",
+        "fsid" : 258,
+        "fstype" : "MacHFS",
+        "name" : "sda1",
+        "nr" : 1,
+        "used_fs": `hfs,
+        "region" : [
+          0,
+          8
+        ],
+        "size_k" : 64260,
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part1"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part1",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda2",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "sda2",
+        "nr" : 2,
+        "region" : [
+          8,
+          131
+        ],
+        "size_k" : 1052257,
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part2"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part2",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/sda3",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 131,
+        "fstopt" : "acl,user_xattr",
+        "fstype" : "Linux native",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "sda3",
+        "nr" : 3,
+        "region" : [
+          139,
+          2471
+        ],
+        "size_k" : 19848307,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "udev_id" : [
+          "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0-part3"
+        ],
+        "udev_path" : "scsi-0:0:0:0-part3",
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `ext4
+      ]
+    ],
+    "proposal_name" : "1. SCSI Disk, 20.00 GiB, /dev/sda, QEMU-QEMU HARDDISK",
+    "sector_size" : 512,
+    "size_k" : 20971520,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "udev_id" : [
+      "scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-0"
+    ],
+    "udev_path" : "scsi-0:0:0:0",
+    "unique" : "WdzZ.f4FMrnpeQ69",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE,
+    "vendor" : "QEMU"
+  ]
+]

--- a/test/fixtures/msdos-root-fat.ycp
+++ b/test/fixtures/msdos-root-fat.ycp
@@ -1,0 +1,118 @@
+$[
+  "/dev/btrfs" : $[
+    "device" : "/dev/btrfs",
+    "name" : "btrfs",
+    "partitions" : [
+    ],
+    "type" : `CT_BTRFS,
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ],
+  "/dev/vda" : $[
+    "bios_id" : "0x80",
+    "bus" : "None",
+    "cyl_count" : 1827,
+    "cyl_size" : 8225280,
+    "device" : "/dev/vda",
+    "driver" : "virtio-pci",
+    "driver_module" : "virtio_pci",
+    "label" : "msdos",
+    "max_logical" : 15,
+    "max_primary" : 4,
+    "name" : "vda",
+    "orig_label" : "gpt",
+    "partitions" : [
+      $[
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda1",
+        "fsid" : 263,
+        "fstype" : "BIOS Grub",
+        "name" : "vda1",
+        "nr" : 1,
+        "region" : [
+          0,
+          1
+        ],
+        "size_k" : 1024,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda2",
+        "format" : true,
+        "fs_options" : $[
+          "opt_dir_index" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-O dir_index",
+            "option_value" : true
+          ],
+          "opt_reg_checks" : $[
+            "option_cmd" : `tunefs,
+            "option_str" : "-c 0 -i 0",
+            "option_value" : true
+          ],
+          "opt_reserved_blocks" : $[
+            "option_cmd" : `mkfs,
+            "option_str" : "-m",
+            "option_value" : "5.0"
+          ]
+        ],
+        "fsid" : 12,
+        "fstopt" : "umask=0002,utf8=true",
+        "fstype" : "Win95 FAT32 LBA",
+        "inactive" : true,
+        "mkfs_opt" : "-O dir_index -m5.0",
+        "mount" : "/",
+        "mountby" : `uuid,
+        "name" : "vda2",
+        "nr" : 2,
+        "region" : [
+          33,
+          1762
+        ],
+        "size_k" : 14153265,
+        "tunefs_opt" : "-c 0 -i 0",
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `vfat,
+        "userdata" : $[
+          "/" : "snapshots"
+        ]
+      ],
+      $[
+        "create" : true,
+        "detected_fs" : `unknown,
+        "device" : "/dev/vda3",
+        "format" : true,
+        "fsid" : 130,
+        "fstype" : "Linux swap",
+        "inactive" : true,
+        "mount" : "swap",
+        "mountby" : `uuid,
+        "name" : "vda3",
+        "nr" : 3,
+        "region" : [
+          1795,
+          32
+        ],
+        "size_k" : 257040,
+        "type" : `primary,
+        "used_by_device" : "",
+        "used_by_type" : `UB_NONE,
+        "used_fs" : `swap
+      ]
+    ],
+    "proposal_name" : "1. Disk, 14.00 GiB, /dev/vda, ",
+    "sector_size" : 512,
+    "size_k" : 14680064,
+    "transport" : `unknown,
+    "type" : `CT_DISK,
+    "unique" : "KSbE.Fxp0d3BezAE",
+    "used_by_device" : "",
+    "used_by_type" : `UB_NONE
+  ]
+]

--- a/test/include/partitioning_custom_part_check_generated_include_test.rb
+++ b/test/include/partitioning_custom_part_check_generated_include_test.rb
@@ -1,0 +1,928 @@
+#!/usr/bin/env rspec
+
+require_relative "../spec_helper"
+
+Yast.import "Arch"
+Yast.import "AutoinstData"
+Yast.import "FileSystems"
+Yast.import "Partitions"
+Yast.import "Popup"
+Yast.import "Product"
+Yast.import "Stage"
+
+describe "Yast::PartitioningCustomPartCheckGeneratedInclude" do
+  FIXTURES_PATH = File.expand_path('../../fixtures', __FILE__)
+
+  # Dummy client to test PartitioningCustomPartCheckGeneratedInclude
+  module DummyYast
+    class StorageClient < Yast::Client
+      include Yast::I18n
+
+      def main
+        Yast.include self, "partitioning/custom_part_check_generated.rb"
+      end
+
+      def initialize
+        main
+      end
+    end
+  end
+
+  # Helper method to load partitioning maps
+  #
+  # Partitioning maps are stored in /test/fixtures as ycp files.
+  #
+  # @param [String] name Map name (without .ycp extension)
+  # @return Hash    Hash representing information contained in the map
+  def build_map(name)
+    path = File.join(FIXTURES_PATH, "#{name}.ycp")
+    content = Yast::SCR.Read(Yast::Path.new(".target.ycp"), path)
+    raise "Fixtures #{name} not found (file #{path}) does not exist)" if content.nil?
+    content
+  end
+
+  subject(:client) { DummyYast::StorageClient.new }
+
+  describe "#check_created_partition_table" do
+    let(:efi) { false } # EFI boot
+    let(:arch) { "x86_64" }
+    let(:boot_mount) { "/boot" }
+    let(:warnings) { true }
+    let(:prep_boot) { false }
+
+    before do
+      allow(Yast::SCR).to receive(:Read).with(path(".target.ycp"), anything).and_call_original
+      allow(Yast::Arch).to receive(:architecture).and_return(arch)
+      allow(Yast::Partitions).to receive(:EfiBoot).and_return(efi)
+      allow(Yast::FileSystems).to receive(:default_subvol).and_return("@")
+      allow(Yast::Product).to receive(:name).and_return("SLES 12 SP1")
+      allow(Yast::AutoinstData).to receive(:BootRaidWarning).and_return(warnings)
+      allow(Yast::AutoinstData).to receive(:BootCylWarning).and_return(warnings)
+      allow(Yast::Partitions).to receive(:BootMount).and_return(boot_mount) # Avoid Partitions cache
+      allow(Yast::Partitions).to receive(:PrepBoot).and_return(prep_boot)
+    end
+
+    context "during installation" do
+      let(:installation) { true }
+
+      before do
+        Yast::Stage.Set("initial")
+      end
+
+      context "target map is ok" do
+        let(:map) { build_map("gpt-btrfs") }
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when root partition is not present" do
+        let(:map) do
+          # remove /root from map
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(2) }
+        end
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/have not assigned a root partition/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when FAT is used for some system mount point (/, /usr, /home, /opt or /var)" do
+        let(:map) { build_map("msdos-root-fat") }
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/You tried to mount a FAT partition/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when BIOS GRUB is not used" do
+        context "and filesystem for /boot partition is Btrfs" do
+          let(:map) { build_map("gpt-btrfs-boot") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/with Btrfs to the\nmount point \/boot/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot partition ends after Partitions.BootCyl" do
+          let(:map) { build_map("msdos-ext4-boot") }
+
+          it "warns the user and returns false" do
+            allow(Yast::Partitions).to receive(:BootCyl).and_return(32)
+            expect(Yast::Popup).to receive(:YesNo).with(/Your boot partition ends above cylinder/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot partition is too small" do
+          let(:map) do
+            build_map("msdos-ext4-boot").tap do |m|
+              m["/dev/vda"]["partitions"][0]["size_k"] = 1024
+            end
+          end
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/Your boot partition is smaller than/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and filesystem is not Btrfs and size and region are ok" do
+          let(:map) { build_map("msdos-ext4-boot") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when PReP/CHRP is needed" do
+        let(:prep_boot) { true }
+
+        before do
+          allow(Yast::Arch).to receive(:board_chrp).and_return(true)
+        end
+
+        context "when /boot partition is not present and machine does not belong to iSeries" do
+          let(:map) do
+            build_map("gpt-ppc-btrfs").tap { |m| m["/dev/sda"]["partitions"].delete_at(0) }
+          end
+
+          before do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(false)
+          end
+
+          it "show a warning and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/There is no partition mounted as \/boot/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and a PReP boot partition is needed but machine belongs to iSeries" do
+          let(:map) do
+            build_map("gpt-ppc-btrfs").tap { |m| m["/dev/sda"]["partitions"].delete_at(0) }
+          end
+
+          before do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and boot partition has no mount point" do
+          let(:map) { build_map("gpt-ppc-btrfs") }
+
+          before do
+            allow(Yast::Arch).to receive(:board_compatible).and_return(true)
+          end
+
+          context "and fsid matches FsidBoot" do
+            it "returns true" do
+              expect(Yast::Popup).to_not receive(:YesNo)
+              expect(client.check_created_partition_table(map, installation)).to eq(true)
+            end
+          end
+
+          context "and fsid is 6" do
+            let(:map) do
+              build_map("gpt-ppc-btrfs").tap do |m|
+                m["/dev/sda"]["partitions"][0].merge!("fsid" => 6, "boot_size_k" => 200000)
+              end
+            end
+
+            it "returns true" do
+              expect(Yast::Popup).to_not receive(:YesNo)
+              expect(client.check_created_partition_table(map, installation)).to eq(true)
+            end
+          end
+
+          context "and fsid does not match FsidBoot" do
+            it "warns the user and returns false" do
+              allow(Yast::Partitions).to receive(:FsidBoot).and_return(1)
+              expect(client.check_created_partition_table(map, installation)).to eq(false)
+            end
+          end
+        end
+      end
+
+      context "when /boot partition is not present" do
+        let(:map) do
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+        end
+
+        context "and root partition ends after Partitions.BootCyl" do
+          let(:map) { build_map("msdos-ext4-boot-root") }
+
+          it "warns the user and returns false" do
+            allow(Yast::Partitions).to receive(:BootCyl).and_return(32)
+            expect(Yast::Popup).to receive(:YesNo).with(/has an end cylinder above 32/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and using a GPT partition table" do
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo)
+              .with(/Warning: There is no partition of type bios_grub present./)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and root is on a RAID1" do
+          let(:map) { build_map("gpt-root-raid1") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID0" do
+          let(:map) { build_map("gpt-root-raid0") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/installation might not be directly bootable/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and root is on a RAID0 but machine belongs to iSeries" do
+          let(:map) { build_map("gpt-root-raid0") }
+
+          it "returns true" do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID0 but warnings are disabled" do
+          let(:map) { build_map("gpt-root-raid0") }
+          let(:warnings) { false }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when boot is on RAID1" do
+        let(:map) { build_map("gpt-boot-raid1") }
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when boot is on RAID0" do
+        context "and machine belongs to iSeries" do
+          let(:map) { build_map("gpt-boot-raid0") }
+
+          it "returns true" do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "but machine does not belongs to iSeries" do
+          let(:map) { build_map("gpt-boot-raid0") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/installation might not be directly bootable/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and warnings are disabled" do
+          let(:map) { build_map("gpt-boot-raid0") }
+          let(:warnings) { false }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when some BTRFS subvolume is shadowed" do
+        let(:map) { build_map("msdos-btrfs-shadowed") }
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/subvolumes of the root filesystem are shadowed/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when no swap is found" do
+        let(:map) do
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(1) }
+        end
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/have not assigned a swap partition/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when some partition is mounted but won't be formatted" do
+        let(:map) do
+          build_map("gpt-btrfs").tap do |m|
+            m["/dev/vda"]["partitions"][2]["format"] = false
+          end
+        end
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/onto an existing partition that will not be\nformatted/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when root is on hardware RAID" do
+        context "and /boot is not found" do
+          let(:map) { build_map("dmraid-ext4-boot-root") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/no \nseparate \/boot partition on your RAID disk./)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot is found" do
+          let(:map) { build_map("dmraid-ext4-boot") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "on board_mac" do
+        before do
+          allow(Yast::Arch).to receive(:board_mac).and_return(true)
+          allow(Yast::Arch).to receive(:board_chrp).and_return(true)
+        end
+
+        context "when boot partition has no mount point an is HFS" do
+          let(:map) { build_map("msdos-hfs") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "on EFI" do
+        let(:efi) { true }
+        let(:boot_mount) { "/boot/efi" }
+
+        context "when FAT is used for /boot" do
+          let(:map) do
+            build_map("gpt-boot-fat").tap do |m|
+              m["/dev/vda"]["partitions"][0]["mount"] = "/boot/efi"
+            end
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) do
+            build_map("msdos-boot-fat").tap do |m|
+              m["/dev/vda"]["partitions"][0]["mount"] = "/boot/efi"
+            end
+          end
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo)
+              .with(/your \/boot partition is located does not contain a GPT/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "when /boot partition is not present" do
+          let(:map) do
+            build_map("gpt-boot-fat").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+          end
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/no\nFAT partition mounted on \/boot/)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+      end
+
+      context "on ia64" do
+        let(:arch) { "ia64" }
+
+        context "when FAT is used for /boot" do
+          let(:map) { build_map("gpt-boot-fat") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) { build_map("msdos-boot-fat") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo)
+              .with(/your \/boot partition is located does not contain a GPT/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot partition is not present" do
+          let(:map) do
+            build_map("msdos-boot-fat").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+          end
+
+          it "shows a dialog and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/no\nFAT partition mounted on \/boot/)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+      end
+
+      context "on no EFI nor ia64" do
+        context "when FAT is used for /boot (no EFI nor ia64)" do
+          let(:map) { build_map("gpt-boot-fat") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/You tried to mount a FAT partition to the/)
+            .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) { build_map("msdos-boot-ext4") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+    end
+
+    context "during normal operation" do
+      let(:installation) { false }
+
+      before do
+        Yast::Stage.Set("normal")
+      end
+
+      context "target map is ok" do
+        let(:map) { build_map("gpt-btrfs") }
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when root partition is not present" do
+        let(:map) do
+          # remove /root from map
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(2) }
+        end
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when FAT is used for some system mount point (/, /usr, /home, /opt or /var)" do
+        let(:map) { build_map("msdos-root-fat") }
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/You tried to mount a FAT partition/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "on EFI" do
+        let(:efi) { true }
+        let(:boot_mount) { "/boot/efi" }
+
+        context "when FAT is used for /boot" do
+          let(:map) do
+            build_map("gpt-boot-fat").tap do |m|
+              m["/dev/vda"]["partitions"][0]["mount"] = "/boot/efi"
+            end
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) do
+            build_map("msdos-boot-fat").tap do |m|
+              m["/dev/vda"]["partitions"][0]["mount"] = "/boot/efi"
+            end
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "when /boot partition is not present" do
+          let(:map) do
+            build_map("gpt-boot-fat").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "on ia64" do
+        let(:arch) { "ia64" }
+
+        context "when FAT is used for /boot" do
+          let(:map) { build_map("gpt-boot-fat") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) { build_map("msdos-boot-fat") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and /boot partition is not present" do
+          let(:map) do
+            build_map("msdos-boot-fat").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "on no EFI nor ia64" do
+        context "when FAT is used for /boot (no EFI nor ia64)" do
+          let(:map) { build_map("gpt-boot-fat") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/You tried to mount a FAT partition to the/)
+            .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "when disk which contains /boot is labeled as 'msdos'" do
+          let(:map) { build_map("msdos-boot-ext4") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when BIOS GRUB is not used" do
+        context "and filesystem for /boot partition is Btrfs" do
+          let(:map) { build_map("gpt-btrfs-boot") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/with Btrfs to the\nmount point \/boot/)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot partition ends after Partitions.BootCyl" do
+          let(:map) { build_map("msdos-ext4-boot") }
+
+          it "returns true" do
+            allow(Yast::Partitions).to receive(:BootCyl).and_return(32)
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and /boot partition is too small" do
+          let(:map) do
+            build_map("msdos-ext4-boot").tap do |m|
+              m["/dev/vda"]["partitions"][0]["size_k"] = 1024
+            end
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and filesystem is not Btrfs and size and region are ok" do
+          let(:map) { build_map("msdos-ext4-boot") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when PReP/CHRP is needed" do
+        let(:prep_boot) { true }
+
+        before do
+          allow(Yast::Arch).to receive(:board_chrp).and_return(true)
+        end
+
+        context "when /boot partition is not present and machine does not belong to iSeries" do
+          let(:map) do
+            build_map("gpt-ppc-btrfs").tap { |m| m["/dev/sda"]["partitions"].delete_at(0) }
+          end
+
+          before do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(false)
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and a PReP boot partition is needed but machine belongs to iSeries" do
+          let(:map) do
+            build_map("gpt-ppc-btrfs").tap { |m| m["/dev/sda"]["partitions"].delete_at(0) }
+          end
+
+          before do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+          end
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and boot partition has no mount point" do
+          let(:map) { build_map("gpt-ppc-btrfs") }
+
+          before do
+            allow(Yast::Arch).to receive(:board_compatible).and_return(true)
+          end
+
+          context "and fsid matches FsidBoot" do
+            it "returns true" do
+              expect(Yast::Popup).to_not receive(:YesNo)
+              expect(client.check_created_partition_table(map, installation)).to eq(true)
+            end
+          end
+
+          context "and fsid is 6" do
+            let(:map) do
+              build_map("gpt-ppc-btrfs").tap do |m|
+                m["/dev/sda"]["partitions"][0].merge!("fsid" => 6, "boot_size_k" => 200000)
+              end
+            end
+
+            it "returns true" do
+              expect(Yast::Popup).to_not receive(:YesNo)
+              expect(client.check_created_partition_table(map, installation)).to eq(true)
+            end
+          end
+
+          context "and fsid does not match FsidBoot" do
+            it "returns true" do
+              allow(Yast::Partitions).to receive(:FsidBoot).and_return(1)
+              expect(Yast::Popup).to_not receive(:YesNo)
+              expect(client.check_created_partition_table(map, installation)).to eq(true)
+            end
+          end
+        end
+      end
+
+      context "when /boot partition is not present" do
+        let(:map) do
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(0) }
+        end
+
+        context "and root partition ends after Partitions.BootCyl" do
+          let(:map) { build_map("msdos-ext4-boot-root") }
+
+          it "returns true" do
+            allow(Yast::Partitions).to receive(:BootCyl).and_return(32)
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and using a GPT partition table" do
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID1" do
+          let(:map) { build_map("gpt-root-raid1") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID0" do
+          let(:map) { build_map("gpt-root-raid0") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID0 but machine belongs to iSeries" do
+          let(:map) { build_map("gpt-root-raid0") }
+
+          it "returns true" do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and root is on a RAID0 but warnings are disabled" do
+          let(:map) { build_map("gpt-root-raid0") }
+          let(:warnings) { false }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when boot is on RAID1" do
+        let(:map) { build_map("gpt-boot-raid1") }
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when boot is on RAID0" do
+        context "and machine belongs to iSeries" do
+          let(:map) { build_map("gpt-boot-raid0") }
+
+          it "returns true" do
+            allow(Yast::Arch).to receive(:board_iseries).and_return(true)
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "but machine does not belongs to iSeries" do
+          let(:map) { build_map("gpt-boot-raid0") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+
+        context "and warnings are disabled" do
+          let(:map) { build_map("gpt-boot-raid0") }
+          let(:warnings) { false }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "when some BTRFS subvolume is shadowed" do
+        let(:map) { build_map("msdos-btrfs-shadowed") }
+
+        it "warns the user and returns false" do
+          expect(Yast::Popup).to receive(:YesNo).with(/subvolumes of the root filesystem are shadowed/)
+            .and_return(false)
+          expect(client.check_created_partition_table(map, installation)).to eq(false)
+        end
+      end
+
+      context "when no swap is found" do
+        let(:map) do
+          build_map("gpt-btrfs").tap { |m| m["/dev/vda"]["partitions"].delete_at(1) }
+        end
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when some partition is mounted but won't be formatted" do
+        let(:map) do
+          build_map("gpt-btrfs").tap do |m|
+            m["/dev/vda"]["partitions"][2]["format"] = false
+          end
+        end
+
+        it "returns true" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(client.check_created_partition_table(map, installation)).to eq(true)
+        end
+      end
+
+      context "when root is on hardware RAID" do
+        context "and /boot is not found" do
+          let(:map) { build_map("dmraid-ext4-boot-root") }
+
+          it "warns the user and returns false" do
+            expect(Yast::Popup).to receive(:YesNo).with(/no \nseparate \/boot partition on your RAID disk./)
+              .and_return(false)
+            expect(client.check_created_partition_table(map, installation)).to eq(false)
+          end
+        end
+
+        context "and /boot is found" do
+          let(:map) { build_map("dmraid-ext4-boot") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+
+      context "on board_mac" do
+        before do
+          allow(Yast::Arch).to receive(:board_mac).and_return(true)
+          allow(Yast::Arch).to receive(:board_chrp).and_return(true)
+        end
+
+        context "when boot partition has no mount point an is HFS" do
+          let(:map) { build_map("msdos-hfs") }
+
+          it "returns true" do
+            expect(Yast::Popup).to_not receive(:YesNo)
+            expect(client.check_created_partition_table(map, installation)).to eq(true)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Reverts 29b5c41, which broke LVM stuff (and who knows what other stuff).
* Find a different solution for bug ([bsc#940374](https://bugzilla.suse.com/show_bug.cgi?id=940374) as @aschnell suggested).
* Fixes the missing PReP/CHRP message. The old message stated that `/boot` partitions would be converted to PReP/CHRP automatically. That's not true.