### PR TITLE
Move check about PReP boot needed to Partitions module

### DIFF
--- a/src/include/partitioning/custom_part_check_generated.rb
+++ b/src/include/partitioning/custom_part_check_generated.rb
@@ -301,7 +301,7 @@ module Yast
 
       # A PReP/CHRP partition is not supposed to be mounted. So if we find any
       # other /boot partition, we should warn the user.
-      if boot_found && Partitions.PrepBoot && !boot_mount_point.empty? && !Arch.board_iseries && installation || show_all_popups
+      if boot_found && Partitions.prep_boot_needed? && !boot_mount_point.empty? && installation || show_all_popups
         message = _(
           "Warning:\n" \
           "Your system needs a boot partition with type 0x41 PReP/CHRP.\n" \
@@ -369,9 +369,7 @@ module Yast
       end
 
       if !boot_found && installation || show_all_popups
-        # iSeries does not really need a boot partition
-        # a bootable binary will be written to a kernel slot in /proc
-        if Partitions.PrepBoot && !Arch.board_iseries && !diskless || show_all_popups
+        if Partitions.prep_boot_needed? && !diskless || show_all_popups
           # popup text
           # If the user chooses 'no' here, the system will not be able to
           # boot from the hard drive!

--- a/src/modules/Partitions.rb
+++ b/src/modules/Partitions.rb
@@ -997,6 +997,17 @@ module Yast
       text
     end
 
+    # Determines whether a PReP boot partition is needed
+    #
+    # iSeries does not really need a boot partition: a bootable binary will be
+    # written to a kernel slot in /proc.
+    #
+    # @return [Boolean] 'true' if boot partition is needed; 'false' otherwise.
+    def prep_boot_needed?
+      PrepBoot() && !Arch.board_iseries
+    end
+    alias_method :prep_boot_needed, :prep_boot_needed?
+
     publish :variable => :fsid_empty, :type => "const integer"
     publish :variable => :fsid_native, :type => "const integer"
     publish :variable => :fsid_swap, :type => "const integer"
@@ -1074,6 +1085,7 @@ module Yast
     publish :function => :MaxLogical, :type => "integer (string)"
     publish :function => :MaxSectors, :type => "integer (string)"
     publish :function => :RdonlyText, :type => "string (map <string, any>, boolean)"
+    publish :function => :prep_boot_needed, :type => "boolean ()"
   end
 
   Partitions = PartitionsClass.new

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,6 +7,7 @@ TESTS = \
 	storage_snapper_configure_snapper_test.rb			\
 	storage_get_disk_partition.rb					\
 	storage_boot_on_raid1.rb \
+	partitions_test.rb \
 	include/partitioning_custom_part_check_generated_include_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/test/partitions_test.rb
+++ b/test/partitions_test.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env rspec
+
+require_relative "spec_helper"
+
+Yast.import "Partitions"
+Yast.import "Arch"
+
+describe Yast::Partitions do
+  subject(:partitions) { Yast::Partitions }
+
+  describe "#prep_boot_needed?" do
+    before do
+      allow(Yast::Partitions).to receive(:PrepBoot).and_return(prep_boot)
+      allow(Yast::Arch).to receive(:board_iseries).and_return(iseries)
+    end
+
+    context "when PrepBoot is true and machine does not belongs to iSeries" do
+      let(:prep_boot) { true }
+      let(:iseries) { false }
+
+      it "returns true" do
+        expect(partitions.prep_boot_needed?).to eq(true)
+      end
+    end
+
+    context "when PrepBoot is false" do
+      let(:prep_boot) { false }
+      let(:iseries) { false }
+
+      it "returns false" do
+        expect(partitions.prep_boot_needed?).to eq(false)
+      end
+    end
+
+    context "when PrepBoot is true and machine belongs to iSeries" do
+      let(:prep_boot) { true }
+      let(:iseries) { true }
+
+      it "returns false" do
+        expect(partitions.prep_boot_needed?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a minor refactoring [proposed by @kobliha](https://github.com/yast/yast-storage/pull/154#discussion_r39385283).