### PR TITLE
Live installer should honor default fs

### DIFF
--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -4503,13 +4503,13 @@ module Yast
       ret = {}
       target = AddWinInfo(target)
       Ops.set(ret, "target", target)
+      opts = GetControlCfg()
       root = {
         "mount"       => "/",
         "increasable" => true,
         "fsys"        => PropDefaultFs(),
         "size"        => 0
       }
-      opts = GetControlCfg()
       ddev = get_disk_try_list(target, true)
       sol_disk = ""
       valid = {}


### PR DESCRIPTION
See https://github.com/yast/yast-storage/issues/178

The call to GetControlCfg needs to be moved before setting up the root structure:
PropDefaultFs() returns proposal_root_fs, which has at that point the default value btrfs - so the proposal is always based on btrfs.
GetControlCfg calls SetProposalDefault, which in turn calls SetProposalRootFs to initialise the root fs type from /etc/sysconfig/storage. Switching both commands would make sure, that the proposal honors the user settings.