### PR TITLE
Fix boo#955103

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 16 17:15:29 UTC 2015 - ushamim@linux.com
+
+- Resolves issue (boo#955103) regarding YaST2 partitioning
+  module allowing you to enter an empty subvolume name.
+- 3.1.74
+
+-------------------------------------------------------------------
 Tue Dec  1 08:43:27 CET 2015 - gs@suse.de
 
 - Revert previous patch for bsc#949683 (adding _netdev is not

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.73
+Version:        3.1.74
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_dialogs.rb
+++ b/src/include/partitioning/custom_part_dialogs.rb
@@ -1664,21 +1664,22 @@ module Yast
           Builtins.y2milestone("SubvolHandling names:%1", SubvolNames(new))
           if pth == nil || Builtins.size(pth) == 0
             Popup.Message(_("Empty subvolume name not allowed."))
-          elsif Ops.greater_than(Builtins.size(FileSystems.default_subvol), 0) &&
-              Builtins.substring(pth, 0, Builtins.size(svtmp)) != svtmp
-            tmp = Builtins.sformat(
-              _(
-                "Only subvolume names starting with \"%1\" currently allowed!\nAutomatically prepending \"%1\" to name of subvolume."
-              ),
-              svtmp
-            )
-            Popup.Message(tmp)
-            pth = svtmp + pth
           elsif Builtins.contains(SubvolNames(new), pth)
             Popup.Message(
               Builtins.sformat(_("Subvolume name %1 already exists."), pth)
             )
           else
+            if Ops.greater_than(Builtins.size(FileSystems.default_subvol), 0) &&
+                Builtins.substring(pth, 0, Builtins.size(svtmp)) != svtmp
+              tmp = Builtins.sformat(
+                _(
+                  "Only subvolume names starting with \"%1\" currently allowed!\nAutomatically prepending \"%1\" to name of subvolume."
+                ),
+                svtmp
+              )
+              Popup.Message(tmp)
+              pth = svtmp + pth
+            end
             Ops.set(
               new,
               "subvol",

--- a/src/include/partitioning/custom_part_dialogs.rb
+++ b/src/include/partitioning/custom_part_dialogs.rb
@@ -1678,17 +1678,23 @@ module Yast
                 svtmp
               )
               Popup.Message(tmp)
-              pth = svtmp + pth
+              pth = svtmp + pth  
             end
-            Ops.set(
-              new,
-              "subvol",
-              Builtins.add(
-                Ops.get_list(new, "subvol", []),
-                { "create" => true, "name" => pth }
+            if Builtins.contains(SubvolNames(new), pth)
+              Popup.Message(
+                Builtins.sformat(_("Subvolume name %1 already exists."), pth)
               )
-            )
-            changed = true
+            else
+              Ops.set(
+                new,
+                "subvol",
+                Builtins.add(
+                  Ops.get_list(new, "subvol", []),
+                  { "create" => true, "name" => pth }
+                )
+              )
+              changed = true
+            end
           end
           items = SubvolNames(new)
           UI.ChangeWidget(Id(:subvol), :Items, items)

--- a/src/include/partitioning/custom_part_dialogs.rb
+++ b/src/include/partitioning/custom_part_dialogs.rb
@@ -1664,10 +1664,6 @@ module Yast
           Builtins.y2milestone("SubvolHandling names:%1", SubvolNames(new))
           if pth == nil || Builtins.size(pth) == 0
             Popup.Message(_("Empty subvolume name not allowed."))
-          elsif Builtins.contains(SubvolNames(new), pth)
-            Popup.Message(
-              Builtins.sformat(_("Subvolume name %1 already exists."), pth)
-            )
           else
             if Ops.greater_than(Builtins.size(FileSystems.default_subvol), 0) &&
                 Builtins.substring(pth, 0, Builtins.size(svtmp)) != svtmp


### PR DESCRIPTION
As discussed in https://github.com/yast/yast-storage/pull/170 making new request to get rid of the noise commits.

Resolves issue regarding YaST2 partitioning module allowing you to enter an empty subvolume name.