### PR TITLE
Tech preview: New proposal based on new libstorage-bgl (part 2)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 21 13:45:50 CET 2015 - shundhammer@suse.de
+
+- Tech preview for new storage proposal based on libstorage-bgl
+- 3.1.75
+
+-------------------------------------------------------------------
 Wed Dec 17 15:15:29 UTC 2015 - ushamim@linux.com
 
 - Resolves issue (boo#955103) regarding YaST2 partitioning

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.74
+Version:        3.1.75
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/storage/disk_analyzer.rb
+++ b/src/lib/storage/disk_analyzer.rb
@@ -293,7 +293,7 @@ module Yast
       def installation_volume?(vol_name)
         log.info("Checking if #{vol_name} is an installation volume")
         is_inst = mount_and_check(vol_name) { |mp| installation_volume_check(mp) }
-        log.info("#{vol_name} is installation medium") if is_inst
+        log.info("#{vol_name} is installation medium: #{is_inst}")
         is_inst
       end
 

--- a/src/lib/storage/disk_analyzer.rb
+++ b/src/lib/storage/disk_analyzer.rb
@@ -141,8 +141,15 @@ module Yast
         log.info("USB Disks:     #{dev_names(usb_disks)}")
         log.info("Non-USB Disks: #{dev_names(non_usb_disks)}")
 
+        # Try with non-USB disks first.
+        candidate_disks = remove_installation_disks(non_usb_disks)
+        if candidate_disks.empty?
+          log.info("No non-USB candidate disks left after eliminating installation disks")
+          log.info("Trying with USB disks")
+          candidate_disks = remove_installation_disks(usb_disks)
+        end
+
         # We don't want to install on our installation disk if there is any other way.
-        candidate_disks = remove_installation_disks(non_usb_disks + usb_disks)
         if candidate_disks.empty?
           log.info("No candidate disks left after eliminating installation disks")
           log.info("Trying with non-USB installation disks")

--- a/src/lib/storage/disk_size.rb
+++ b/src/lib/storage/disk_size.rb
@@ -130,6 +130,7 @@ module Yast
       #
 
       def +(other)
+        return DiskSize.unlimited if any_operand_unlimited?(other)
         if other.is_a?(Numeric)
           DiskSize.new(@size_k + other)
         elsif other.respond_to?(:size_k)
@@ -140,6 +141,7 @@ module Yast
       end
 
       def -(other)
+        return DiskSize.unlimited if any_operand_unlimited?(other)
         if other.is_a?(Numeric)
           DiskSize.new(@size_k - other)
         elsif other.respond_to?(:size_k)
@@ -151,6 +153,7 @@ module Yast
 
       def *(other)
         if other.is_a?(Numeric)
+        return DiskSize.unlimited if unlimited?
           DiskSize.new(@size_k * other)
         else
           raise TypeError, "Unexpected #{other.class}; expected Numeric value"
@@ -159,6 +162,7 @@ module Yast
 
       def /(other)
         if other.is_a?(Numeric)
+        return DiskSize.unlimited if unlimited?
           DiskSize.new(@size_k.to_f / other)
         else
           raise TypeError, "Unexpected #{other.class}; expected Numeric value"
@@ -221,6 +225,15 @@ module Yast
 
       def pretty_print(*)
         print "#{inspect}"
+      end
+
+      private
+
+      # Return 'true' if either self or other is unlimited.
+      #
+      def any_operand_unlimited?(other)
+        return true if unlimited?
+        return other.respond_to?(:unlimited?) && other.unlimited?
       end
     end
   end

--- a/src/lib/storage/space_maker.rb
+++ b/src/lib/storage/space_maker.rb
@@ -54,7 +54,7 @@ module Yast
       # @param windows_partitions [Array<string>] device names of Windows
       #        partitions that can possibly be resized
       #
-      # @param devicegraph [Storage::Devicegraph] device graph to use for any
+      # @param devicegraph [Storage::Devicegraph] devicegraph to use for any
       #        changes, typically StorageManager.instance.devicegraph("proposal")
       #
       def initialize(settings: ,
@@ -119,8 +119,9 @@ module Yast
         rescue RuntimeError => ex  # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
           log.info("CAUGHT exception #{ex}")
         end
+        disk.remove_descendants
         ptable_type ||= disk.default_partition_table_type
-        disk.create_partition_table(ptable_type) # this implicitly deletes all partitions
+        disk.create_partition_table(ptable_type)
       end
 
       # Delete one partition.

--- a/src/lib/storage/space_maker.rb
+++ b/src/lib/storage/space_maker.rb
@@ -57,7 +57,7 @@ module Yast
       # @param devicegraph [Storage::Devicegraph] devicegraph to use for any
       #        changes, typically StorageManager.instance.devicegraph("proposal")
       #
-      def initialize(settings: ,
+      def initialize(settings:,
                      volumes:            [],
                      candidate_disks:    [],
                      linux_partitions:   [],
@@ -134,6 +134,7 @@ module Yast
       #
       def delete_partition(partition)
         # TO DO
+        partition
       end
 
       # Calculate total sum of all 'size_method' fields of @volumes.
@@ -144,7 +145,9 @@ module Yast
       # @return [DiskSize] sum of all 'size_method' in @volumes
       #
       def total_vol_sizes(size_method)
-        @volumes.reduce(DiskSize.zero) { |sum, vol| sum += vol.method(size_method).call }
+        @volumes.reduce(DiskSize.zero) do |sum, vol|
+          sum + vol.method(size_method).call
+        end
       end
 
       # Calculate total sum of all desired sizes of @volumes.
@@ -158,7 +161,7 @@ module Yast
       #
       def total_desired_sizes
         @volumes.reduce(DiskSize.zero) do |sum, vol|
-          sum += vol.desired_size.unlimited? ? vol.min_size : vol.desired_size
+          sum + vol.desired_size.unlimited? ? vol.min_size : vol.desired_size
         end
       end
     end

--- a/src/lib/storage/space_maker.rb
+++ b/src/lib/storage/space_maker.rb
@@ -57,6 +57,7 @@ module Yast
       end
 
       # Try to detect empty (unpartitioned) space.
+      #
       def find_space
         @free_space = []
         @disk_analyzer.candidate_disks.each do |disk|
@@ -75,14 +76,37 @@ module Yast
 
       # Use force to create space: Try to resize an existing Windows
       # partition or delete partitions until there is enough free space.
+      #
       def make_space
         # TO DO
       end
 
       # Resize an existing MS Windows partition to free up disk space.
+      #
       def resize_windows_partition(partition)
         # TO DO
         partition
+      end
+
+      # Delete all partitions on a disk.
+      #
+      # @param disk [::storage::Disk]
+      #
+      def delete_all_partitions(disk)
+        ptable_type = nil
+        begin
+          ptable_type = disk.partition_table.type
+        rescue RuntimeError => ex  # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
+          log.info("CAUGHT exception #{ex}")
+        end
+        ptable_type ||= disk.default_partition_table_type
+        disk.create_partition_table(ptable_type) # this implicitly deletes all partitions
+      end
+
+      # Delete one partition.
+      #
+      def delete_partition(partition)
+        # TO DO
       end
     end
   end

--- a/src/lib/storage/space_maker.rb
+++ b/src/lib/storage/space_maker.rb
@@ -161,7 +161,7 @@ module Yast
       #
       def total_desired_sizes
         @volumes.reduce(DiskSize.zero) do |sum, vol|
-          sum + vol.desired_size.unlimited? ? vol.min_size : vol.desired_size
+          sum + (vol.desired_size.unlimited? ? vol.min_size : vol.desired_size)
         end
       end
     end

--- a/src/lib/storage/space_maker.rb
+++ b/src/lib/storage/space_maker.rb
@@ -111,10 +111,11 @@ module Yast
       # @param disk [::storage::Disk]
       #
       def delete_all_partitions(disk_name)
+        log.info("Deleting all partitions on #{disk_name}")
         ptable_type = nil
         begin
           disk = ::Storage::Disk.find(@devicegraph, disk_name)
-          ptable_type = disk.partition_table.type
+          ptable_type = disk.partition_table.type # might throw if no partition table
         rescue RuntimeError => ex  # FIXME: rescue ::Storage::Exception when SWIG bindings are fixed
           log.info("CAUGHT exception #{ex}")
         end

--- a/src/lib/storage/storage_proposal.rb
+++ b/src/lib/storage/storage_proposal.rb
@@ -63,6 +63,7 @@ module Yast
 
       # Create a storage proposal.
       def propose
+        StorageManager.start_probing
         prepare_devicegraphs
 
         boot_requirements_checker = BootRequirementsChecker.new(@settings)
@@ -134,7 +135,7 @@ module Yast
       # If no PROPOSAL_BASE devicegraph exists yet, it will be copied from PROBED.
       #
       def prepare_devicegraphs
-        storage = StorageManager.instance # this will start probing in the first invocation
+        storage = StorageManager.instance
         storage.copy_devicegraph(PROBED, PROPOSAL_BASE) unless storage.exist_devicegraph(PROPOSAL_BASE)
         reset_proposal
       end

--- a/src/lib/storage/storage_proposal.rb
+++ b/src/lib/storage/storage_proposal.rb
@@ -54,7 +54,6 @@ module Yast
       STAGING       = "staging"
 
       def initialize
-        @storage  = nil
         @settings = ProposalSettings.new
         @proposal = nil # ::Storage::DeviceGraph
         @disk_blacklist = []
@@ -82,36 +81,37 @@ module Yast
         space_maker.find_space
         space_maker.delete_all_partitions("/dev/sda")
         proposal_to_staging
-        calc_actions
         action_text = proposal_text
         log.info("Actions:\n#{action_text}\n")
         print("\nActions:\n\n#{action_text}\n")
       end
 
       # Return the textual description of the actions necessary to transform
-      # the probed device graph into the staging device graph.
+      # the probed devicegraph into the staging devicegraph.
       #
       def proposal_text
         return "No storage proposal possible" unless @actions
-        @actions.commit_actions_as_strings.join("\n")
+        @actions.commit_actions_as_strings.to_a.join("\n")
       end
 
       # Reset the proposal devicegraph (PROPOSAL) to PROPOSAL_BASE.
       #
       def reset_proposal
-        log.debug("Resetting proposal device graph")
+        log.debug("Resetting proposal devicegraph")
         storage = StorageManager.instance
         storage.remove_devicegraph(PROPOSAL) if storage.exist_devicegraph(PROPOSAL)
         @proposal = storage.copy_devicegraph(PROPOSAL_BASE, PROPOSAL)
         @actions  = nil
       end
 
-      # Copy the PROPOSAL device graph to STAGING so actions can be calculated
+      # Copy the PROPOSAL devicegraph to STAGING so actions can be calculated
       # or commited
       #
       def proposal_to_staging
-        StorageManager.instance.copy_devicegraph(PROPOSAL, STAGING)
-        @actions = StorageManager.instance.calculate_actiongraph
+        storage = StorageManager.instance
+        storage.remove_devicegraph(STAGING) if storage.exist_devicegraph(STAGING)
+        storage.copy_devicegraph(PROPOSAL, STAGING)
+        @actions = storage.calculate_actiongraph
       end
 
       private

--- a/src/lib/storage/storage_proposal.rb
+++ b/src/lib/storage/storage_proposal.rb
@@ -146,8 +146,9 @@ module Yast
       # @return [Array [ProposalVolume]]
       #
       def standard_volumes
-        volumes = [make_root_vol]
-        volumes << make_home_vol if @settings.use_separate_home
+        root_vol = make_root_vol
+        volumes = [root_vol]
+        volumes << make_home_vol(root_vol.desired_size) if @settings.use_separate_home
         volumes
       end
 
@@ -166,6 +167,7 @@ module Yast
           root_vol.max_size *= multiplicator
         end
         root_vol.desired_size = root_vol.max_size
+        pp root_vol
         root_vol
       end
 
@@ -174,11 +176,13 @@ module Yast
       #
       # This does NOT create the partition yet, only the data structure.
       #
-      def make_home_vol
+      def make_home_vol(root_vol_size)
         home_vol = ProposalVolume.new("/home", @settings.home_filesystem_type)
         home_vol.min_size = @settings.home_min_size
         home_vol.max_size = @settings.home_max_size
-        home_vol.desired_size = home_vol.max_size
+        home_percent = 100.0 - @settings.root_space_percent
+        home_vol.desired_size = root_vol_size * (home_percent / @settings.root_space_percent)
+        pp home_vol
         home_vol
       end
     end

--- a/src/lib/storage/storage_proposal.rb
+++ b/src/lib/storage/storage_proposal.rb
@@ -73,7 +73,12 @@ module Yast
         disk_analyzer = DiskAnalyzer.new
         disk_analyzer.analyze
 
-        space_maker = SpaceMaker.new(@volumes, @settings, disk_analyzer)
+        space_maker = SpaceMaker.new(settings: @settings,
+                                     volumes:  @volumes,
+                                     candidate_disks:    disk_analyzer.candidate_disks,
+                                     linux_partitions:   disk_analyzer.linux_partitions,
+                                     windows_partitions: disk_analyzer.windows_partitions,
+                                     devicegraph: @proposal)
         space_maker.find_space
       end
 

--- a/src/lib/storage/storage_proposal.rb
+++ b/src/lib/storage/storage_proposal.rb
@@ -167,7 +167,6 @@ module Yast
           root_vol.max_size *= multiplicator
         end
         root_vol.desired_size = root_vol.max_size
-        pp root_vol
         root_vol
       end
 
@@ -182,7 +181,6 @@ module Yast
         home_vol.max_size = @settings.home_max_size
         home_percent = 100.0 - @settings.root_space_percent
         home_vol.desired_size = root_vol_size * (home_percent / @settings.root_space_percent)
-        pp home_vol
         home_vol
       end
     end

--- a/test/disk_size_test.rb
+++ b/test/disk_size_test.rb
@@ -109,6 +109,29 @@ describe Yast::Storage::DiskSize do
     end
   end
 
+  describe "arithmetic operations with unlimited and DiskSize" do
+    unlimited = Yast::Storage::DiskSize.unlimited
+    disk_size = Yast::Storage::DiskSize.GiB(42)
+    it "should return unlimited" do
+      expect( unlimited + disk_size ).to be == unlimited
+      expect( disk_size + unlimited ).to be == unlimited
+      expect( unlimited - disk_size ).to be == unlimited
+      expect( disk_size - unlimited ).to be == unlimited
+      # DiskSize * DiskSize and DiskSize / DiskSize are undefined
+    end
+  end
+
+  describe "arithmetic operations with unlimited and a number" do
+    unlimited = Yast::Storage::DiskSize.unlimited
+    number    = 7
+    it "should return unlimited" do
+      expect( unlimited + number ).to be == unlimited
+      expect( unlimited - number ).to be == unlimited
+      expect( unlimited * number ).to be == unlimited
+      expect( unlimited / number ).to be == unlimited
+    end
+  end
+
   describe "comparison" do
     disk_size1 = Yast::Storage::DiskSize.GiB(24)
     disk_size2 = Yast::Storage::DiskSize.GiB(32)


### PR DESCRIPTION
This is not complete according to the PBI yet.

(Major) changes to the last version:

- Now using device names wherever possible, not C++ -meets-Ruby-objects from libstorage
  (this should be easier to test in an isolated way)

- Use libstorage-bgl to find unpartitioned space

- Actually change things using libstorage-bgl calls:
 Right now, the candidate disk is flattened (destroying all partitions and the partition table) for demonstration purposes.

- Introduced an intermediate libstorage-bgl devicegraph "proposal-base" to handle scenarios where the user selects a disk or partitions to be deleted to make room for the Linux installation (available now, too); that would be a copy of the probed devicegraph with those partitions already deleted. The general idea is to revert to this devicegraph when the proposal goes wrong or when the user wants to change proposal settings (with or without LVM, with or without separate home, etc.).

- Using a devicegraph "proposal" that starts as a copy of "proposal-base" to calculate the proposal.

- Creating an actiongraph with libstorage-bgl: This is the diff between the probed devicegraph and the "proposal" devicegraph.

- Using libstorage-bgl to get a textual description of the actions that will be performed (if the user commits those changes when confirming the installation).