### PR TITLE
Expert part: subvolumes also for LVM and raid (bsc#967191)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 12:43:40 UTC 2016 - ancor@suse.com
+
+- Expert partitioner: ensure btrfs subvolumes are properly created
+  also in RAID and LVM devices (bsc#967191)
+- 3.1.78
+
+-------------------------------------------------------------------
 Wed Feb 17 15:42:04 UTC 2016 - ancor@suse.com
 
 - Expert partitioner: improve the shadowed subvolumes handling.

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.77
+Version:        3.1.78
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/ep-loop-dialogs.rb
+++ b/src/include/partitioning/ep-loop-dialogs.rb
@@ -253,7 +253,8 @@ module Yast
           (
             data_ref = arg_ref(data.value);
             _MiniWorkflowStepFormatMount_result = MiniWorkflowStepFormatMount(
-              data_ref
+              data_ref,
+              creating: true
             );
             data.value = data_ref.value;
             _MiniWorkflowStepFormatMount_result

--- a/src/include/partitioning/ep-lvm-dialogs.rb
+++ b/src/include/partitioning/ep-lvm-dialogs.rb
@@ -995,7 +995,8 @@ module Yast
           (
             data_ref = arg_ref(data.value);
             _MiniWorkflowStepFormatMount_result = MiniWorkflowStepFormatMount(
-              data_ref
+              data_ref,
+              creating: true
             );
             data.value = data_ref.value;
             _MiniWorkflowStepFormatMount_result

--- a/src/include/partitioning/ep-raid-dialogs.rb
+++ b/src/include/partitioning/ep-raid-dialogs.rb
@@ -611,7 +611,8 @@ module Yast
           (
             data_ref = arg_ref(data.value);
             _MiniWorkflowStepFormatMount_result = MiniWorkflowStepFormatMount(
-              data_ref
+              data_ref,
+              creating: true
             );
             data.value = data_ref.value;
             _MiniWorkflowStepFormatMount_result

--- a/src/include/partitioning/ep-tmpfs-dialogs.rb
+++ b/src/include/partitioning/ep-tmpfs-dialogs.rb
@@ -35,7 +35,8 @@ module Yast
         (
           data_ref = arg_ref(data.value);
           _MiniWorkflowStepFormatMount_result = MiniWorkflowStepFormatMount(
-            data_ref
+            data_ref,
+            creating: true
           );
           data.value = data_ref.value;
           _MiniWorkflowStepFormatMount_result


### PR DESCRIPTION
This is a fix for https://bugzilla.suse.com/show_bug.cgi?id=967191

The bug was introduced here https://github.com/yast/yast-storage/pull/189

Manually tested.