### PR TITLE
	Never try to reuse partitions if any DASD is involved (bsc#983003)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  4 18:07:03 CEST 2016 - shundhammer@suse.de
+
+- Never try to reuse partitions if any DASD is involved (bsc#983003)
+- 3.1.95
+
+-------------------------------------------------------------------
 Tue Jun  7 11:23:00 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.94
+Version:        3.1.95
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This is a workaround for https://bugzilla.suse.com/show_bug.cgi?id=983003

The proposal tried to create an illegal 4th partition on a DASD on s/390 in certain scenarios (only 3 partitions are allowed on DASDs). We could not track down the exact problem, but this is a workaround:

The storage proposal tries several modes:

- free: Use available free disk space

- resize: Resize available partitions (Windows on PCs)

- reuse: Reuse existing partitions

- remove: Remove single partitions to make space

- desperate: Delete all partitions on the installation disk

In this workaround, we skip "reuse" and to straight to "desperate", but only if we are installing on DASDs (more specific: if any of the candidate disks is a DASD).

I tested this on a QEMU installation where I temporarily replaced the comparison string from /dev/dasd to /dev/vda.