### PR TITLE
Don't oversize /boot in aarch64 with UEFI bsc#984874

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 29 11:14:26 UTC 2016 - ancor@suse.com
+
+- Fixed installer proposed size of /boot partition for aarch64
+  systems using UEFI (bsc#984874)
+- 3.1.98
+
+-------------------------------------------------------------------
 Fri Jul 29 07:21:29 UTC 2016 - ancor@suse.com
 
 - If the user has skipped LUKS activation, don't ask again after

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.97
+Version:        3.1.98
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Partitions.rb
+++ b/src/modules/Partitions.rb
@@ -225,7 +225,7 @@ module Yast
         }
         Ops.set(@boot_size_k, :proposed, 150 * 1024) if EfiBoot()
 
-        if Arch.aarch64
+        if Arch.aarch64 && !EfiBoot()
           # Has higher requirements on BTRFS since pagesize==sectorsize = 64k
           # See bsc#979037
           Ops.set(@boot_size_k, :proposed, 660 * 1024)


### PR DESCRIPTION
Tested manually. Seems to work.