### PR TITLE
- Fixed message suggesting to add PReP partition (bsc#988783)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 15 16:27:58 CEST 2016 - aschnell@suse.com
+
+- Fixed message suggesting to add PReP partition (bsc#988783)
+- 3.1.100
+
+-------------------------------------------------------------------
 Wed Aug 10 08:19:49 UTC 2016 - ancor@suse.com
 
 - Do not ignore suggestion made by partitioning proposal of turning

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.99
+Version:        3.1.100
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_check_generated.rb
+++ b/src/include/partitioning/custom_part_check_generated.rb
@@ -297,7 +297,8 @@ module Yast
       if boot_found && Partitions.prep_boot_needed? && !boot_mount_point.empty? && installation || show_all_popups
         message = _(
           "Warning:\n" \
-          "Your system needs a boot partition with type 0x41 PReP/CHRP.\n" \
+          "Your system needs a boot partition, either with type 0x41 PReP/CHRP\n" \
+          "on MS-DOS or type 0x00 GPT PReP Boot on GPT.\n" \
           "Please, consider creating one.\n" \
           "\n" \
           "Really use this setup?\n"
@@ -371,7 +372,8 @@ module Yast
               "Warning: There is no partition mounted as /boot.\n" +
                 "To boot from your hard disk, a small /boot partition\n" +
                 "(approx. %1) is required.  Consider creating one\n" +
-                "with type 0x41 PReP/CHRP.\n" +
+                "with type 0x41 PReP/CHRP on MS-DOS or type 0x00 GPT\n" +
+                "PReP Boot on GPT.\n" +
                 "\n" +
                 "Really use the setup without /boot partition?\n"
             ),


### PR DESCRIPTION
For https://trello.com/c/RZnByOJj/423-3-12-sp2-p1-bug-988783-sles12-sp2-beta4-configuring-a-ppc-prep-boot-partition-on-a-gpt-partition-table-fails-with-an-error.