### PR TITLE
Self update cleanup

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 26 08:18:42 UTC 2016 - igonzalezsosa@suse.com
+
+- Don't check for installer restart as it's not needed anymore
+  (bsc#985055)
+- 3.1.102
+
+-------------------------------------------------------------------
 Fri Aug 19 12:27:18 UTC 2016 - jsrain@suse.cz
 
 - added /var/lib/machines to the list of subvolumes (bsc#992573)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.101
+Version:        3.1.102
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Storage.rb
+++ b/src/modules/Storage.rb
@@ -7163,7 +7163,7 @@ module Yast
   protected
 
     def skip_activation_popup?
-      Mode.autoinst || Mode.autoupgrade || Installation.restarting?
+      Mode.autoinst || Mode.autoupgrade
     end
 
     def propose_new_fsid(part, id)


### PR DESCRIPTION
Don't check for installer restart as it's not needed anymore after moving self-update to the beginning of the installation.