### PR TITLE
fixed bsc#910791

### DIFF
--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.103
+Version:        3.1.104
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_lib.rb
+++ b/src/include/partitioning/custom_part_lib.rb
@@ -293,13 +293,17 @@ module Yast
 
       if Ops.less_than(size_k, min_size_k)
         # warning message, %1 is replaced by fs name (e.g. Ext3)
-        # %2 is prelaced by a size (e.g. 10 MB)
+        # %2 is replaced by the user entered size (e.g. 20GB)
+        # %3 is replaced by a size (e.g. 10 MB)
         Popup.Warning(
           Builtins.sformat(
             _(
-              "Your partition is too small to use %1.\nThe minimum size for this file system is %2.\n"
+              "Your partition is too small to use %1.\n" +
+                "The size you entered (after rounding up) is %2.\n" +
+                "The minimum size for this file system is %3.\n"
             ),
             FileSystems.GetName(fs, ""),
+            Storage.KByteToHumanString(size_k),
             Storage.KByteToHumanString(min_size_k)
           )
         )

--- a/src/include/partitioning/custom_part_lib.rb
+++ b/src/include/partitioning/custom_part_lib.rb
@@ -291,7 +291,7 @@ module Yast
         min_size_k
       )
 
-      if Ops.less_than(size_k, min_size_k)
+      if size_k < min_size_k
         # warning message, %1 is replaced by fs name (e.g. Ext3)
         # %2 is replaced by the user entered size (e.g. 20GB)
         # %3 is replaced by a size (e.g. 10 MB)

--- a/yast-storage.changes
+++ b/yast-storage.changes
@@ -1,0 +1,5 @@
+-------------------------------------------------------------------
+Sat Sep 24 14:47:48 UTC 2016 - dwaas@suse.com
+
+- Avoid confusion in small partition warning by displaying also rounded input value (bsc#910791)
+- 3.1.104


### PR DESCRIPTION
COMMIT MESSAGE

```

warning message for too small disks was made more detailed to avoid
situations in which the rounding would actually cause a deliberately
false message.

e.g.
Inputting 11MiB and getting as a message:

"Your partition is too small to use ext3.
The minimum size for this file system is 10.00 MiB"
```

EXTRA COMMENTS

1) tested on LEAP  42.1
2) locally make check wasn't succeeding 100% likely because I only took the latest libstorage and yast-storage checkouts and use the rest from usual packages distributed in openSUSE Leap.
3) the remote package build succeeds (osc build) with the following output:
... 
 [   65s] 3 packages and 0 specfiles checked; 0 errors, 8 warnings.    

4) Please DO note that the current fix leaks information through the abstractions. I'm looking forward to discuss better phrasing to this fix.

some ideas could be:

"The machine interpreted %s", size_k
etc...
