### PR TITLE
[WIP] Set default subvolume name

### DIFF
--- a/src/modules/FileSystems.rb
+++ b/src/modules/FileSystems.rb
@@ -31,6 +31,7 @@
 # $Id$
 require "storage"
 require "yast"
+require "yast2/execute"
 
 module Yast
   class FileSystemsClass < Module


### PR DESCRIPTION
Just a test PR to find out the problem with requiring yast2/execute. @jreidinger pointed out that `cheetah` and `abstract_method` gems should be added to `.travis.yml`.