### PR TITLE
Add subvol.rb to Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,7 +92,8 @@ ylib_DATA = \
   lib/storage/target_map_formatter.rb \
   lib/storage/used_storage_features.rb \
   lib/storage/shadowed_vol_list.rb \
-  lib/storage/shadowed_vol_helper.rb
+  lib/storage/shadowed_vol_helper.rb \
+  lib/storage/subvol.rb
 
 scrconf_DATA = \
   scrconf/proc_partitions.scr \


### PR DESCRIPTION
Add the missing `lib/storage/subvol.rb` file. I'm not bumping the version number because version 3.1.103 has not been submitted yet. 