### PR TITLE
Expert partitioner less restrictive with encryption

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Wed Jan 25 18:16:05 CET 2017 - shundhammer@suse.de
+
+- Don't force separate /boot partition in expert partitioner
+  (fate#320215)
+- Expert partitioner less restrictive with encryption
+  for system mount points (/, /usr/, /var, /opt)
+  and for Btrfs, LVM PVs, RAID
+- 3.2.5
+
+-------------------------------------------------------------------
 Tue Jan 10 16:03:29 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix initialization of partitioning/btrfs_default_subvolume

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.4
+Version:        3.2.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_lib.rb
+++ b/src/include/partitioning/custom_part_lib.rb
@@ -35,7 +35,6 @@ module Yast
       Yast.import "Greasemonkey"
 
       Yast.include include_target, "partitioning/partition_defines.rb"
-
     end
 
     # Check lvm mount points
@@ -108,26 +107,6 @@ module Yast
       ret
     end
 
-    # Check crypted mount points and return true if the mount point is ok.
-    # @param [String] mount mount point
-    # @param [Boolean] crypt_fs boolean
-    # @return [Boolean]
-    #
-    def check_crypt_fs_mount_points(mount, crypt_fs)
-      if crypt_fs && FileSystems.IsCryptMp(mount, false)
-        # error popup text
-        Popup.Error(
-          _(
-            "You have assigned an encrypted file system to a partition\n" +
-              "with one of the following mount points: \"/\", \"/usr\", \"/boot\",\n" +
-              "/var\".  This is not possible. Change the mount point or use a\n" +
-              "nonloopbacked file system.\n"
-          )
-        )
-        return false
-      end
-      true
-    end
     def check_unique_label(targetMap, part)
       targetMap = deep_copy(targetMap)
       part = deep_copy(part)
@@ -148,6 +127,7 @@ module Yast
       end
       unique
     end
+
     def CheckFstabOptions(part)
       part = deep_copy(part)
       ret = true
@@ -339,13 +319,6 @@ module Yast
         end
         if UI.WidgetExists(Id(:crypt_fs))
           crypt_fs = Convert.to_boolean(UI.QueryWidget(Id(:crypt_fs), :Value))
-        end
-        if !check_crypt_fs_mount_points(
-            Ops.get_string(new, "mount", ""),
-            crypt_fs
-          )
-          Ops.set(ret, "ok", false)
-          Ops.set(ret, "field", :mount_point)
         end
         if Ops.get_boolean(new, "noauto", false) &&
             !check_noauto_mount(Ops.get_string(new, "mount", ""))

--- a/src/include/partitioning/custom_part_lib.rb
+++ b/src/include/partitioning/custom_part_lib.rb
@@ -481,7 +481,6 @@ module Yast
 
       if apply_change && UI.WidgetExists(Id(:crypt_fs))
         cr = Ops.get_boolean(selected_fs, :crypt, true) &&
-          Ops.get_symbol(new, "used_fs", :unknown) != :btrfs &&
           !Ops.get_boolean(new, "pool", false)
         Builtins.y2milestone("HandleFsChanged cr:%1", cr)
 
@@ -816,10 +815,8 @@ module Yast
           if no_fs
             UI.ChangeWidget(Id(:do_not_mount), :Value, true)
             ChangeExistingSymbolsState([:fs_options, :fs], false)
-            ChangeExistingSymbolsState(
-              [:crypt_fs],
-              fs_int == Partitions.fsid_lvm
-            )
+            enable_crypt = [Partitions.fsid_lvm, Partitions.fsid_raid].include?(fs_int)
+            ChangeExistingSymbolsState([:crypt_fs], enable_crypt)
           elsif fs_int == Partitions.fsid_native
             Ops.set(new, "used_fs", Partitions.DefaultFs)
             UI.ChangeWidget(

--- a/src/include/partitioning/ep-dialogs.rb
+++ b/src/include/partitioning/ep-dialogs.rb
@@ -208,7 +208,6 @@ module Yast
           :crypt_fs,
           :Enabled,
           Ops.get_boolean(fs_data, :crypt, true) &&
-            Ops.get_symbol(data, "used_fs", :unknown) != :btrfs &&
             !Ops.get_boolean(data, "pool", false)
         )
 
@@ -445,7 +444,7 @@ module Yast
       #not there in RAID/LVM/loop configuration (#483789)
       ChangeWidgetIfExists(:do_not_format_attachment, :Enabled, !do_format)
 
-      _EnableDisableFsOpts.call(used_fs) if do_format
+      _EnableDisableFsOpts.call(used_fs)
 
       #not there on s390s
       ChangeWidgetIfExists(:crypt_fs, :Value, crypt_fs)

--- a/src/modules/FileSystems.rb
+++ b/src/modules/FileSystems.rb
@@ -360,12 +360,14 @@ module Yast
           :name            => "LVM",
           :fsid            => Partitions.fsid_lvm,
           :supports_format => false,
+          :crypt           => true,
           :fsid_item       => "0x8E Linux LVM "
         },
         :raid       => {
           :name            => "RAID",
           :fsid            => Partitions.fsid_raid,
           :supports_format => false,
+          :crypt           => true,
           :fsid_item       => "0xFD Linux RAID "
         },
         :xbootdisk  => {


### PR DESCRIPTION
https://trello.com/c/4IojS1Y5/490-2-12-sp3-fate-320215-allow-full-lvm-encryption-with-msdos-mbr-without-extra-boot

The FATE request was really about not forcing the user to create a separate /boot partition when using encryption: Grub2 learned how to handle booting from encrypted partitions, from encrypted LVM, even from encrypted RAIDs.

The expert partitioner never enforced that, but it wouldn't let you use a "system mount point" (/, /usr/, /var, /opt (???)) when selecting encryption for a partition. This restriction is now lifted.

Along with it, more restrictions are now lifted: It wouldn't allow a Btrfs partition or LVM logical volume to be encrypted (why??), and it wouldn't allow encryption on an LVM physical volume (which doesn't make any sense since this is exactly what the partitioning proposal does) or encryption on a partition used by a RAID. This is now possible, but the user still has to know what he is doing.

Caveat: The user has to enter the encryption password twice in some scenarios, once for Grub2 to load kernel and initrd, and once later when systemd starts mounting filesystems. This is a limitation that was accepted by the Fate stakeholders (and it would have to be fixed by the Grub or systemd people anyway).

Caveat 2: The expert partitioner tries to be smart - in some cases too smart. When wildly clicking around all the options on the "Add partition" dialog, there may be situations when some widgets are enabled or disabled when they really shouldn't. In that case, the user might need to go back to the previous step in that sub-workflow.