### PR TITLE
Warn user in expert partitioner if Btrfs root partition is too small for snapshots (Fate#320416)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  7 16:59:55 CET 2017 - shundhammer@suse.de
+
+- Warn user in expert partitioner if Btrfs root partition is too
+  small for snapshots (Fate#320416)
+- 3.2.8
+
+-------------------------------------------------------------------
 Thu Feb  2 16:42:01 CET 2017 - shundhammer@suse.de
 
 - Move snapshots check box to "edit partition" dialog (Fate#321094)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.7
+Version:        3.2.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/partitioning/custom_part_check_generated.rb
+++ b/src/include/partitioning/custom_part_check_generated.rb
@@ -862,7 +862,6 @@ module Yast
     # @return [Boolean] true if ok, false if a warning should be shown
     #
     def check_root_for_snapshot_size(part)
-      log.info("check_root_for_snapshot_size: part: #{part}")
       return true unless Mode.installation
       return true unless part["mount"] == "/"
       return true unless part["used_fs"] == :btrfs
@@ -892,10 +891,7 @@ module Yast
     #
     def recommended_root_size_k_for_snapshots
       proposal_settings = StorageProposal.GetControlCfg()
-      root_base_k = 1024 * (proposal_settings["root_base"] || 0)
-      btrfs_inc = proposal_settings["btrfs_increase_percentage"] || 0
-      log.info("recommended_root: base: #{root_base_k/(1024*1024.0)} GiB inc: #{btrfs_inc}%")
-      root_base_k * (1.0 + btrfs_inc / 100.0)
+      1024 * (proposal_settings["root_base"] || 0)
     end
 
     # Show a warning that the root partition is too small.


### PR DESCRIPTION
https://trello.com/c/vYz5fsL9/483-2-12-sp3-fate-320416-warn-if-user-enables-snapshots-on-too-small-root-filesystem

Screenshot: 

https://w3.suse.de/~shundhammer/snapshots-size-warning/snapshots-size-warning.png
