### PR TITLE
Don't complain about unavailable NTFS packages if they are not   in the product's repo (bsc#1039830)

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 30 16:53:14 CEST 2017 - shundhammer@suse.de
+
+- Don't complain about unavailable NTFS packages if they are not
+  in the product's repo (bsc#1039830)
+- 3.2.14
+
+-------------------------------------------------------------------
 Tue May 23 11:02:17 UTC 2017 - igonzalezsosa@suse.com
 
 - Read default subvolume name for Btrfs filesystems when using

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.13
+Version:        3.2.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/storage/used_storage_features.rb
+++ b/src/lib/storage/used_storage_features.rb
@@ -95,6 +95,17 @@ module Yast
           # Other
           FT_QUOTA:         "quota"
         }
+
+      # Storage-related packages that are nice to have, but not absolutely
+      # required.
+      #
+      # SLES-12 for example (unlike SLED-12) does not come with NTFS packages,
+      # so they cannot be installed. But there might already be an existing
+      # NTFS Windows partition on the disk; don't throw an error pop-up in that
+      # case, just log a warning (bsc#1039830).
+      #
+      OPTIONAL_PACKAGES = [ "ntfs-3g", "ntfsprogs" ]
+      #
       # configurable part ends here
       #======================================================================
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1039830

Added new list for optional packages. If the corresponding storage feature is used, but those packages are not available in the repos, only log a warning and continue anyway.

Tested manually with SLE-12-SP3-Server-DVD-x86_64-Build0405-Media1.iso .