### PR TITLE
Merged SLE-12-SP2-CASP branch to SLE-12-SP3 branch

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -3,7 +3,7 @@ Tue Aug  8 14:18:06 CEST 2017 - shundhammer@suse.de
 
 - Merged SLE-12-SP2-CASP branch to SLE-12-SP3 branch
   (bsc#1051200, bsc#1051210)
-- 3.2.17 
+- 3.2.16.1
 
 -------------------------------------------------------------------
 Thu Jul 20 10:45:18 CEST 2017 - aschnell@suse.com

--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,21 @@
 -------------------------------------------------------------------
+Tue Aug  8 14:18:06 CEST 2017 - shundhammer@suse.de
+
+- Merged SLE-12-SP2-CASP branch to SLE-12-SP3 branch
+  (bsc#1051200, bsc#1051210)
+- 3.2.17 
+
+-------------------------------------------------------------------
+Thu Jul 20 10:45:18 CEST 2017 - aschnell@suse.com
+
+- fixed check whether snapshots are proposed (bsc#1049108)
+
+-------------------------------------------------------------------
+Mon Jun 26 11:13:00 CEST 2017 - shundhammer@suse.de
+
+- Allow different mount point for home partition (Fate#323532)
+
+-------------------------------------------------------------------
 Fri Jun 16 08:07:04 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix Btrfs default subvolume name detection (bsc#1044434 and

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.16
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.17
+Version:        3.2.16.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://trello.com/c/zCKSIBHK/633-1-merge-caasp-hack-for-separate-data-partition-to-sle-12-sp3-branch

# Test Scenarios:

![part-ext4-sep-home](https://user-images.githubusercontent.com/11538225/29076469-eea255ae-7c55-11e7-8764-6c67dc306331.png)

Partition-based with ext4 root and separate /home


------------------------------------

![part-ext4-no-home](https://user-images.githubusercontent.com/11538225/29076490-fdb7c52e-7c55-11e7-860a-4721c64e66e3.png)

Partition-based with ext4 root and no separate /home


------------------------------------

![part-btrfs-no-home](https://user-images.githubusercontent.com/11538225/29076514-10b9d450-7c56-11e7-83c5-3e33ef114c91.png)

Partition-based with btrfs and no separate /home. Notice the home subvolume.


------------------------------------

![part-btrfs-separate-home](https://user-images.githubusercontent.com/11538225/29076518-140dc2d8-7c56-11e7-9d59-ac1c4bc6cc87.png)

LVM with btrfs and separate /home. Notice **no** home subvolume.


------------------------------------

![lvm-btrfs-no-home](https://user-images.githubusercontent.com/11538225/29076543-1fd68dc0-7c56-11e7-87c4-0cb72a38f5ff.png)

LVM with btrfs and no separate /home. Notice the home subvolume.


------------------------------------

![lvm-btrfs-separate-home](https://user-images.githubusercontent.com/11538225/29076550-232f8c06-7c56-11e7-91df-3a47ece629a4.png)

LVM with btrfs and separate /home. Notice no home subvolume.
