### PR TITLE
Make fs type for home and root configurable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "yast/rake"
 
 Yast::Tasks.submit_to :casp10
+obs_project = "Devel:YaST:CASP:1.0"
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now

--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 16 11:34:48 CEST 2017 - shundhammer@suse.de
+
+- Make filesystem type for home and root configurable in control.xml
+  (bsc#1051762)
+- 3.1.108.4 
+
+-------------------------------------------------------------------
 Thu Jul 20 10:45:18 CEST 2017 - aschnell@suse.com
 
 - fixed check whether snapshots are proposed (bsc#1049108)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.1.108.3
+Version:        3.1.108.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -328,6 +328,9 @@ module Yast
         end
         log.info("home_path: #{@home_path}") unless @home_path == DEFAULT_HOME_PATH
 
+        @proposal_home_fs = get_fs_type_from_control_xml("home_fs", @proposal_home_fs)
+        @proposal_root_fs = get_fs_type_from_control_xml("root_fs", @proposal_root_fs)
+
         btmp = ProductFeatures.GetBooleanFeature("partitioning", "proposal_lvm")
         Ops.set(@cfg_xml, "prop_lvm", btmp ? true : false)
 
@@ -6681,6 +6684,19 @@ module Yast
     def strategy=(value)
       SetProposalLvm([:lvm, :lvm_crypt].include?(value))
       SetProposalEncrypt(value == :lvm_crypt)
+    end
+
+    # Get a filesystem type from control.xml.
+    #
+    # @param [String] name  key below "partitioning" in control.xml
+    # @param [Symbol] fallback  fallback value if not present in control.xml
+    # @return [Symbol] filesystem type (:btrfs, :xfs, :ext4, ...)
+    #
+    def get_fs_type_from_control_xml(name, fallback)
+      fs = ProductFeatures.GetStringFeature("partitioning", name) || fallback
+      fs = fs.downcase.to_sym unless fs.is_a?(Symbol)
+      log.info("#{name}: #{fs}") unless fs == fallback
+      fs
     end
 
     publish :function => :SetCreateVg, :type => "void (boolean)"


### PR DESCRIPTION
https://trello.com/c/SQQ1x4Bg/691-5-suse-caasp-10-p2-1051762-docker-on-xfs-by-default

This makes the filesystem type for both home and root in the storage proposal configurable: When home_fs is configurable, root_fs is only a heartbeat away, and it's trivial to add it at the same time.

Test against SLE-12 SP3:

![home_fs_sp3](https://user-images.githubusercontent.com/11538225/29368427-f4cd0af0-829f-11e7-8823-0e48cf0f162a.png)

Test against CaaSP 1.0:


    2017-08-16 13:55:59 <1> f218(14753) [libstorage] Storage.cc(dumpCommitInfos):4876 ChangeText
    
    Delete partition /dev/vda2 (29.41 GiB) [destructive]
    ChangeText Delete partition /dev/vda3 (7.58 GiB) [destructive]
    
    ChangeText Create root volume /dev/vda2 (29.59 GiB) with btrfs
    ChangeText Create volume /dev/vda3 (7.40 GiB) for /var/lib/docker with btrfs
    
    ChangeText Create subvolume @/boot/grub2/i386-pc on device /dev/vda2
    ChangeText Create subvolume @/boot/grub2/x86_64-efi on device /dev/vda2
    ChangeText Create subvolume @/cloud-init-config on device /dev/vda2
    ChangeText Create subvolume @/home on device /dev/vda2
    ChangeText Create subvolume @/root on device /dev/vda2
    ChangeText Create subvolume @/tmp on device /dev/vda2
    ChangeText Create subvolume @/var/cache on device /dev/vda2
    ChangeText Create subvolume @/var/crash on device /dev/vda2
    ChangeText Create subvolume @/var/lib/ca-certificates on device /dev/vda2
    ChangeText Create subvolume @/var/lib/cloud on device /dev/vda2
    ChangeText Create subvolume @/var/lib/dockershim on device /dev/vda2
    ChangeText Create subvolume @/var/lib/etcd on device /dev/vda2 with option "no copy on write"
    ChangeText Create subvolume @/var/lib/kubelet on device /dev/vda2 with option "no copy on write"
    ChangeText Create subvolume @/var/lib/machines on device /dev/vda2
    ChangeText Create subvolume @/var/lib/misc on device /dev/vda2
    ChangeText Create subvolume @/var/lib/mysql on device /dev/vda2 with option "no copy on write"
    ChangeText Create subvolume @/var/lib/nfs on device /dev/vda2
    ChangeText Create subvolume @/var/lib/ntp on device /dev/vda2
    ChangeText Create subvolume @/var/lib/overlay on device /dev/vda2
    ChangeText Create subvolume @/var/lib/rollback on device /dev/vda2
    ChangeText Create subvolume @/var/lib/systemd on device /dev/vda2
    ChangeText Create subvolume @/var/lib/vmware on device /dev/vda2
    ChangeText Create subvolume @/var/lib/wicked on device /dev/vda2
    ChangeText Create subvolume @/var/log on device /dev/vda2
    ChangeText Create subvolume @/var/spool on device /dev/vda2
    ChangeText Create subvolume @/var/tmp on device /dev/vda2
    ChangeText Use /dev/vda1 as swap

