### PR TITLE
Merged SLE-12-SP2-CASP and SLE-12-SP3 to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ testsuite/run
 testsuite/config
 test-driver
 compile
+/.yardoc
+/doc/autodocs
+/coverage

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--markup markdown
+--protected
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,29 @@
 -------------------------------------------------------------------
+Wed Aug 23 14:13:02 CEST 2017 - shundhammer@suse.de
+
+- Merged SLE-12-SP2-CASP branch to master
+- 3.2.18
+
+-------------------------------------------------------------------
+Mon Aug 21 10:32:52 UTC 2017 - igonzalezsosa@suse.com
+
+- Fix Btrfs default subvolume name detection (bsc#1044434 and
+  bsc#1044250)
+- Read default subvolume name for Btrfs filesystems when using
+  the expert partitioner (bsc#1040154)
+
+-------------------------------------------------------------------
+Wed Aug 16 11:34:48 CEST 2017 - shundhammer@suse.de
+
+- Make filesystem type for home and root configurable in control.xml
+  (bsc#1051762)
+
+-------------------------------------------------------------------
+Thu Jul 20 10:45:18 CEST 2017 - aschnell@suse.com
+
+- fixed check whether snapshots are proposed (bsc#1049108)
+
+-------------------------------------------------------------------
 Mon Jun 26 11:13:00 CEST 2017 - shundhammer@suse.de
 
 - Allow different mount point for home partition (Fate#323532)

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.17
+Version:        3.2.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -356,6 +356,9 @@ module Yast
 
         SetProposalDefault(false)
         Builtins.y2milestone("GetControlCfg cfg_xml: %1", @cfg_xml)
+
+        @proposal_home_fs = get_fs_type_from_control_xml("home_fs", @proposal_home_fs)
+        @proposal_root_fs = get_fs_type_from_control_xml("root_fs", @proposal_root_fs)
       end
       ret = deep_copy(@cfg_xml)
       Builtins.y2milestone(
@@ -6601,7 +6604,7 @@ module Yast
       ret = false
       if GetProposalSnapshots()
         prop_target_map.each do |device, container|
-          container["partitions"].each do |volume|
+          container.fetch("partitions", []).each do |volume|
             if !volume.fetch("delete", false)
               if volume.fetch("used_fs", :none) == :btrfs && volume.fetch("mount", "") == "/"
                 userdata = volume.fetch("userdata", {})
@@ -6681,6 +6684,20 @@ module Yast
     def strategy=(value)
       SetProposalLvm([:lvm, :lvm_crypt].include?(value))
       SetProposalEncrypt(value == :lvm_crypt)
+    end
+
+    # Get a filesystem type from control.xml.
+    #
+    # @param [String] name  key below "partitioning" in control.xml
+    # @param [Symbol] fallback  fallback value if not present in control.xml
+    # @return [Symbol] filesystem type (:btrfs, :xfs, :ext4, ...)
+    #
+    def get_fs_type_from_control_xml(name, fallback)
+      fs = ProductFeatures.GetStringFeature("partitioning", name)
+      fs = fallback if fs.nil? || fs.empty?
+      fs = fs.downcase.to_sym unless fs.is_a?(Symbol)
+      log.info("#{name}: #{fs}") unless fs == fallback
+      fs
     end
 
     publish :function => :SetCreateVg, :type => "void (boolean)"


### PR DESCRIPTION
https://trello.com/c/sBRQZEzW/670-3-caasp-p1-bnc-1049108-installer-internal-error-in-storageproposalrb

The relevant commit from that PBI is just one of many here, but we should sync yast-storage-old to master anyway to minimize the confusion.

Since it won't be used very much anymore in factory, having all the CASP and 12-SP2 fixes here won't break anything, and it might actually be useful for some things. For any future developement, yast-storage-ng is used anyway.

To get a better overview what this PR is actually doing, switch to the "files" view here.
Basically it's Arvin's commit for the original bug of that PBI and my hack-upon-the-hack commit to make the filesystem types configurable for the home and the root partition.