### PR TITLE
Escape %{VERSION} in the spec file

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  7 11:48:33 UTC 2017 - igonzalezsosa@suse.com
+
+- Properly escape %{VERSION} in the spec file (bsc#1071724).
+- 3.2.20
+
+-------------------------------------------------------------------
 Thu Nov 30 06:38:15 UTC 2017 - rbrown@suse.com
 
 - Replace references to /var/adm/fillup-templates with new

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-storage
-Version:        3.2.19
+Version:        3.2.20
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -131,7 +131,7 @@ rm -f $RPM_BUILD_ROOT/%{yast_plugindir}/libpy2StorageCallbacks.so
 
 %package devel
 Requires:	libstdc++-devel
-Requires:	libstorage-devel = %(echo `rpm -q --queryformat '%{VERSION}' libstorage-devel`)
+Requires:	libstorage-devel = %(echo `rpm -q --queryformat '%%{VERSION}' libstorage-devel`)
 Requires:	yast2-storage = %version
 
 Summary:        YaST2 - Storage Library Headers and Documentation


### PR DESCRIPTION
* It fixes bsc#1071724.

Travis is expected to fail (see [this comment](https://github.com/yast/yast-storage/pull/293#issuecomment-348164397)).