### PR TITLE
- fixed hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use the new [yast2-storage-ng](https://github.com/yast/yast-storage-ng) module i
 GIT
 ---
 
-If you want to see the last state check the [*master_old*](../tree/master_old) branch.
+If you want to see the last state check the [*master_old*](../../tree/master_old) branch.
 
 Use the *SLE12-SPx* branches for the SLE12 maintenance.
 


### PR DESCRIPTION
Without the patch the link is broken when I visit https://github.com/yast/yast-storage/.