### PR TITLE
Consistent Home Limit Check

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 27 16:19:54 UTC 2018 - shundhammer@suse.com
+
+- Consistent home limit check (bsc#1085169)
+- 3.2.17
+
+-------------------------------------------------------------------
 Thu Aug  2 18:14:46 UTC 2018 - knut.anderssen@suse.com
 
 - Allowed to go back or cancel in the inst_disk_proposal client

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.16.4
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -387,6 +387,9 @@ module Yast
     end
 
 
+    # Return the name of the LVM volume group if the product is configured to
+    # create an LVM-based proposal and an empty string if it should be a
+    # partition-based proposal.
     def GetProposalVM
       ret = ""
       ret = "system" if @proposal_lvm
@@ -4583,6 +4586,8 @@ module Yast
       disk_names.any? { |disk| is_dasd?(disk) }
     end
 
+    # Make a partition-based storage proposal.
+    # This is called from get_inst_prop().
     def get_inst_proposal(target)
       target = deep_copy(target)
       Builtins.y2milestone("get_inst_proposal start")
@@ -5684,6 +5689,8 @@ module Yast
     end
 
 
+    # Make an LVM-based (VM: "Volume Manager") storage proposal.
+    # This is called from get_inst_prop().
     def get_inst_prop_vm(target, key)
       target = deep_copy(target)
       Builtins.y2milestone("get_inst_prop_vm start key %1", key)
@@ -6066,6 +6073,7 @@ module Yast
     end
 
 
+    # Make a storage proposal for AutoYaST.
     def get_proposal_vm(target, key, disk)
       target = deep_copy(target)
       disk = deep_copy(disk)
@@ -6191,6 +6199,9 @@ module Yast
     end
 
 
+    # Toplevel entry function for a storage proposal during installation.
+    # For a partition-based proposal, this will call get_inst_proposal().
+    # For an LVM-based proposal, this will call get_inst_prop_vm().
     def get_inst_prop(target)
       # initialize data from control file earlier, it is needed in this function
       # to decide whether to use LVM proposal (bsc#957913)

--- a/src/modules/StorageProposal.rb
+++ b/src/modules/StorageProposal.rb
@@ -3975,16 +3975,15 @@ module Yast
       avail_size = get_avail_size_mb(Ops.get_list(disk, "partitions", []))
       if !have_swap
         swap_sizes = get_swap_sizes(avail_size)
+        swap_size_mb = swap_sizes[0] || 256
         swap = {
           "mount"       => "swap",
           "increasable" => true,
           "fsys"        => :swap,
           "maxsize"     => 2 * 1024 * 1024 * 1024,
-          "size"        => Ops.multiply(
-            Ops.multiply(Ops.get(swap_sizes, 0, 256), 1024),
-            1024
-          )
+          "size"        => swap_size_mb * 1024 * 1024
         }
+        avail_size -= swap_size_mb
         Ops.set(
           conf,
           "partitions",


### PR DESCRIPTION
### Trello

https://trello.com/c/CRZ147Oh/186-5-sles12-sp4-p3-1085169-build-0230-openqa-test-fails-in-partitioninglvm-fails-to-propose-home-partition-put-proposed-itself

### Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1085169

# Problem

yast-storage-old checked the limit when to propose a separate home partition differently between

- partition-based proposal
- LVM-based proposal (both plain and encrypted)

In one case, it took the other partitions that needed to be created into account (swap, /boot, /efi-boot), in the other it didn't. This is inconsistent.

# Ideal Solution

Make the proposal ~~great again~~ consistent in all cases. Always take the other partitions into account.

# Pragmatic Solution

Take the swap partition into account and just ignore the boot partition(s). This is what this PR does.

While it would be nice to be exact, the code adding a boot partition is all over the place in StorageProposal.rb and its 117 functions in its 6722 lines of code. That old code can only handle one single boot partition; it's either `/boot` or PreP or an EFI boot partition or whatever; if it's anything else than `/boot`, it is modified for its true purpose as a final step. This does not make the code any clearer.

Anyway, since a boot partition is only a few MiB anyway, this doesn't change the overall calculation that much; this is about the same order of magnitude than overhead due to LVM management which in the other case would also cause a slight difference. I think we can live with that.

Trying not to overengineer this.