### PR TITLE
Fix LVM VG resize

### DIFF
--- a/package/yast2-storage.changes
+++ b/package/yast2-storage.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  6 15:16:08 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Partitioner: PVs are not wrongly removed when resizing a VG
+  (bsc#1197208).
+- 3.2.23
+
+-------------------------------------------------------------------
 Fri Sep 27 10:40:48 CEST 2019 - aschnell@suse.com
 
 - reuse at most 20 swap devices (plus potentially more handled

--- a/package/yast2-storage.spec
+++ b/package/yast2-storage.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-storage
-Version:        3.2.22
+Version:        3.2.23
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,6 +10,7 @@ TESTS = \
 	storage_boot_on_raid1_test.rb 					 \
 	partitions_test.rb 						 \
 	include/partitioning_custom_part_check_generated_include_test.rb \
+	include/ep-lvm-lib_test.rb 					 \
 	subvol_test.rb 							 \
         ro_text_test.rb
 

--- a/test/include/ep-lvm-lib_test.rb
+++ b/test/include/ep-lvm-lib_test.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+
+describe "Yast::PartitioningEpLvmLibInclude" do
+  # Dummy client
+  module DummyYast
+    class StorageClient < Yast::Client
+      include Yast::I18n
+
+      def main
+        Yast.include self, "partitioning/ep-lvm-lib.rb"
+      end
+
+      def initialize
+        main
+      end
+    end
+  end
+
+  subject { DummyYast::StorageClient.new }
+
+  describe "#device_kernel_name" do
+    let(:target_map) do
+      {
+        "/dev/mapper/mpathne" => {
+          "device"=>"/dev/mapper/mpathne",
+          "udev_id"=> ["dm-uuid-mpath-360050768108100bff000000000000824", "dm-name-mpathne"],
+          "partitions"=> [
+            {
+              "device"=>"/dev/mapper/mpathne-part1",
+              "udev_id"=> [
+                "dm-uuid-part1-mpath-360050768108100bff000000000000824",
+                "dm-name-mpathne-part1"
+              ]
+            }
+          ]
+        },
+        "/dev/mapper/mpathnn" => {
+          "device"=>"/dev/mapper/mpathnn",
+          "udev_id"=> ["dm-uuid-mpath-360050768108100bff000000000000825", "dm-name-mpathnn"],
+          "partitions"=> [
+            {
+              "device"=>"/dev/mapper/mpathnn-part1",
+              "udev_id"=> [
+                "dm-uuid-part1-mpath-360050768108100bff000000000000825",
+                "dm-name-mpathnn-part1"
+              ]
+            }
+          ]
+        }
+      }
+    end
+
+    context "when the given name is a known kernel name" do
+      let(:device) { "/dev/mapper/mpathne" }
+
+      it "returns the given name" do
+        expect(subject.device_kernel_name(target_map, device)).to eq(device)
+      end
+    end
+
+    context "when the given name is a unknown kernel name" do
+      let(:device) { "/dev/mapper/mpathnz" }
+
+      it "returns the given name" do
+        expect(subject.device_kernel_name(target_map, device)).to eq(device)
+      end
+    end
+
+    context "when the given name is a known device udev name" do
+      let(:device) { "/dev/disk/by-id/dm-uuid-mpath-360050768108100bff000000000000824" }
+
+      it "returns the device kernel name" do
+        expect(subject.device_kernel_name(target_map, device)).to eq("/dev/mapper/mpathne")
+      end
+    end
+
+    context "when the given name is a known partition udev name" do
+      let(:device) { "/dev/disk/by-id/dm-uuid-part1-mpath-360050768108100bff000000000000825" }
+
+      it "returns the partition kernel name" do
+        expect(subject.device_kernel_name(target_map, device)).to eq("/dev/mapper/mpathnn-part1")
+      end
+    end
+
+    context "when the given name is a unknown udev name" do
+      let(:device) { "/dev/disk/by-id/dm-uuid-mpath-360050768108100bff000000000000899" }
+
+      it "returns the given device" do
+        expect(subject.device_kernel_name(target_map, device)).to eq(device)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In some cases, the target map contains a LVM VG that uses udev names instead of kernel names for its LVM PVs. When this happens, the current PVs are not found in the list of PVs after resizing. This implies that YaST will accidentaly try to remove and add such PVs.

* https://bugzilla.suse.com/show_bug.cgi?id=1197208
* https://trello.com/c/O3JvxmSG/2909-bignum-too-big-to-convert-into-long-long-rangeerror

## Solution

Always use kernel names when looking for the PVs after resizing a VG.

## Testing

- Added new unit tests
- Tested manually by customer

I was not able to reproduce an scenario in which the PVs are pointed by udev names. A DUD was provided to the customer to check this fix.